### PR TITLE
[codex] Ignore Codex workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 install/
 log/
 .github/
+.codex*


### PR DESCRIPTION
## What changed
Adds `.codex*` to `.gitignore` so local Codex workspace files do not get picked up as repository changes.

## Why
These files are local tooling artifacts and should stay out of commits and pull requests.

## Impact
Reduces accidental noise in the working tree and keeps repository history focused on source changes.

## Validation
Reviewed the `.gitignore` diff locally and committed only that file.