### PR TITLE
Add particle filter localization pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Simple meaning:
 
 This package is the current learning stage.
 
-It starts a simple particle filter.
+It runs a first working particle filter localizer.
 
 It reads:
 
@@ -65,9 +65,19 @@ It reads:
 It publishes:
 
 - `/particlecloud`
+- `/likelihood_field`
+- `/estimated_pose`
+- TF: `map -> odom`
 
-For now, the particles are initialized on free map cells and moved with odometry.
-The laser scan is subscribed, but it is not used for particle weights yet.
+It uses the saved map, odometry, and laser scans to estimate the robot pose.
+The particle filter:
+
+- starts particles on free map cells
+- builds a likelihood field from the map
+- moves particles using odometry with small motion noise
+- scores particles using laser scans
+- resamples after robot movement
+- publishes the estimated pose and the normal ROS `map -> odom` transform
 
 ## Quick Start
 
@@ -160,15 +170,6 @@ ros2 run teleop_twist_keyboard teleop_twist_keyboard
 rviz2
 ```
 
-For now the TF tree is not complete.
-Use this temporary static transform:
-
-```bash
-ros2 run tf2_ros static_transform_publisher 0 0 0 0 0 0 map odom
-```
-
-This says: "for now, treat `map` and `odom` as the same frame."
-
 ### 4. Publish the saved map
 
 Start the map server:
@@ -193,10 +194,16 @@ In RViz:
 
 - set Fixed Frame to `map`
 - add the `/map` topic
+- add the `/likelihood_field` topic
 - add the `/particlecloud` topic
+- add the `/estimated_pose` topic
 
 The `/particlecloud` topic shows the particles.
 Each particle is one possible robot pose.
+The `/estimated_pose` topic shows the current best pose estimate.
+
+Do not run a static `map -> odom` transform during localization.
+The localization node publishes `map -> odom`.
 
 ## Project Structure
 
@@ -213,5 +220,6 @@ gazebo_ws/
 
 - Simulation works.
 - Mapping works as a basic occupancy grid mapper.
-- Localization has the first particle filter structure.
-- Localization still needs laser scan scoring and resampling.
+- Localization has a first working particle filter.
+- Localization publishes `/particlecloud`, `/likelihood_field`, `/estimated_pose`, and `map -> odom`.
+- Localization still needs tuning and later improvements, such as better scan scoring and confidence output.

--- a/src/localization/README.md
+++ b/src/localization/README.md
@@ -21,10 +21,6 @@ Right now it can:
 - publish one estimated robot pose on `/estimated_pose`
 - publish the `map -> odom` transform
 
-Right now it does not yet:
-
-- decide when resampling is needed instead of resampling on every scan
-
 So this is now a working first particle-filter localization version.
 It can localize visually in RViz and publish the normal ROS localization TF.
 
@@ -158,6 +154,8 @@ Bad particles get lower scores.
 After scoring, resampling keeps more good particles and removes more bad particles.
 This package uses stochastic universal resampling.
 This is also called low-variance resampling.
+The node only resamples after odometry has moved the particles.
+This avoids repeatedly shrinking the particle cloud while the robot is standing still.
 
 The node also publishes `/estimated_pose`.
 It averages the particle positions.
@@ -193,7 +191,7 @@ map -> odom -> base_link
 The current version is good for learning and visual testing.
 Later we should improve:
 
-- resample only when needed, not necessarily on every scan
+- use effective sample size to decide when resampling is needed
 - improve the laser sensor model
 - publish confidence information, so we know how certain the estimate is
 - add parameters for particle count, beam step, noise, and resampling behavior

--- a/src/localization/README.md
+++ b/src/localization/README.md
@@ -19,15 +19,15 @@ Right now it can:
 - resample particles using stochastic universal resampling
 - publish particles on `/particlecloud`
 - publish one estimated robot pose on `/estimated_pose`
+- publish the `map -> odom` transform
 
 Right now it does not yet:
 
-- publish the `map` to `odom` transform
 - add realistic noise to the odometry motion model
 - decide when resampling is needed instead of resampling on every scan
 
 So this is now a working first particle-filter localization version.
-It can localize visually in RViz, but it is not a full ROS navigation localizer yet.
+It can localize visually in RViz and publish the normal ROS localization TF.
 
 ## Topics
 
@@ -42,6 +42,7 @@ It publishes:
 - `/particlecloud`
 - `/likelihood_field`
 - `/estimated_pose`
+- TF: `map -> odom`
 
 `/particlecloud` is a `PoseArray`.
 In RViz, each pose is drawn as one arrow.
@@ -55,6 +56,14 @@ Cells far from walls have low values.
 `/estimated_pose` is a `PoseStamped`.
 It is one pose calculated from the particle cloud.
 This is the package's current best guess of the robot pose.
+
+The `map -> odom` transform connects the global map frame to the odometry frame.
+Gazebo already publishes `odom -> base_link`.
+Together they form:
+
+```text
+map -> odom -> base_link
+```
 
 ## Build
 
@@ -89,29 +98,24 @@ rviz2
 Terminal 4:
 
 ```bash
-ros2 run tf2_ros static_transform_publisher 0 0 0 0 0 0 map odom
-```
-
-This is a temporary fix.
-It says `map` and `odom` are the same frame.
-
-Terminal 5:
-
-```bash
 ros2 run nav2_map_server map_server --ros-args -p yaml_filename:=src/mapping/maps/maze_map.yaml
 ```
 
-Terminal 6:
+Terminal 5:
 
 ```bash
 ros2 run nav2_util lifecycle_bringup map_server
 ```
 
-Terminal 7:
+Terminal 6:
 
 ```bash
 ros2 run localization localization_node
 ```
+
+Do not run the old static `map -> odom` transform.
+The localization node now publishes `map -> odom`.
+If two nodes publish the same transform, TF can become confused.
 
 In RViz:
 
@@ -167,12 +171,26 @@ These are almost the same direction.
 A normal average would give the wrong answer.
 The sine/cosine average handles this better.
 
+The node also publishes `map -> odom`.
+The idea is:
+
+```text
+map_to_odom = map_to_base_link * inverse(odom_to_base_link)
+```
+
+`map_to_base_link` comes from the particle filter estimate.
+`odom_to_base_link` comes from Gazebo odometry TF.
+The result lets ROS use this standard frame chain:
+
+```text
+map -> odom -> base_link
+```
+
 ## Later Improvements
 
 The current version is good for learning and visual testing.
 Later we should improve:
 
-- publish the `map -> odom` transform
 - add motion noise, because real odometry is not perfect
 - resample only when needed, not necessarily on every scan
 - improve the laser sensor model

--- a/src/localization/README.md
+++ b/src/localization/README.md
@@ -11,20 +11,23 @@ The package has a first particle filter.
 Right now it can:
 
 - read a map from `/map`
+- build and publish a likelihood field on `/likelihood_field`
 - create 500 particles on free map cells
 - read odometry from `/odom`
 - move the particles when the robot moves
+- use `/scan` to score particles
+- resample particles using stochastic universal resampling
 - publish particles on `/particlecloud`
+- publish one estimated robot pose on `/estimated_pose`
 
 Right now it does not yet:
 
-- use the laser scan to score particles
-- resample particles
-- publish the best robot pose
 - publish the `map` to `odom` transform
+- add realistic noise to the odometry motion model
+- decide when resampling is needed instead of resampling on every scan
 
-So this is not a full localization system yet.
-It is the first step.
+So this is now a working first particle-filter localization version.
+It can localize visually in RViz, but it is not a full ROS navigation localizer yet.
 
 ## Topics
 
@@ -37,10 +40,21 @@ The localization node subscribes to:
 It publishes:
 
 - `/particlecloud`
+- `/likelihood_field`
+- `/estimated_pose`
 
 `/particlecloud` is a `PoseArray`.
 In RViz, each pose is drawn as one arrow.
 Each arrow means one possible robot position and direction.
+
+`/likelihood_field` is an `OccupancyGrid`.
+It shows where laser hits are likely.
+Cells near walls have high values.
+Cells far from walls have low values.
+
+`/estimated_pose` is a `PoseStamped`.
+It is one pose calculated from the particle cloud.
+This is the package's current best guess of the robot pose.
 
 ## Build
 
@@ -103,10 +117,13 @@ In RViz:
 
 - set Fixed Frame to `map`
 - add `/map`
+- add `/likelihood_field`
 - add `/particlecloud`
+- add `/estimated_pose`
 
 Then drive the robot with teleop.
-You should see the particles move.
+You should see the particles move and converge near the robot.
+You should also see `/estimated_pose` near the center of the particle cloud.
 
 ## How It Works
 
@@ -124,9 +141,40 @@ This means: "the robot could be anywhere free."
 When odometry says the robot moved, every particle moves too.
 This means: "if the robot moved forward, every guess should move forward."
 
-The next step is to use `/scan`.
-The laser scan should tell which particles match the map well.
-Good particles should get high weight.
-Bad particles should get low weight.
+When a laser scan arrives, each particle gets a score.
+The score asks:
 
-After that, resampling can keep good particles and remove bad particles.
+"If the robot were at this particle, would the laser hits land near walls?"
+
+Good particles get higher scores.
+Bad particles get lower scores.
+
+After scoring, resampling keeps more good particles and removes more bad particles.
+This package uses stochastic universal resampling.
+This is also called low-variance resampling.
+
+The node also publishes `/estimated_pose`.
+It averages the particle positions.
+For the heading angle, it averages `sin(theta)` and `cos(theta)`.
+This avoids a common angle problem.
+
+Example:
+
+- `179 degrees`
+- `-179 degrees`
+
+These are almost the same direction.
+A normal average would give the wrong answer.
+The sine/cosine average handles this better.
+
+## Later Improvements
+
+The current version is good for learning and visual testing.
+Later we should improve:
+
+- publish the `map -> odom` transform
+- add motion noise, because real odometry is not perfect
+- resample only when needed, not necessarily on every scan
+- improve the laser sensor model
+- publish confidence information, so we know how certain the estimate is
+- add parameters for particle count, beam step, noise, and resampling behavior

--- a/src/localization/README.md
+++ b/src/localization/README.md
@@ -23,7 +23,6 @@ Right now it can:
 
 Right now it does not yet:
 
-- add realistic noise to the odometry motion model
 - decide when resampling is needed instead of resampling on every scan
 
 So this is now a working first particle-filter localization version.
@@ -144,6 +143,9 @@ This means: "the robot could be anywhere free."
 
 When odometry says the robot moved, every particle moves too.
 This means: "if the robot moved forward, every guess should move forward."
+The motion model adds small random noise.
+This means particles do not all move in exactly the same way.
+That is useful because real odometry is not perfect.
 
 When a laser scan arrives, each particle gets a score.
 The score asks:
@@ -191,7 +193,6 @@ map -> odom -> base_link
 The current version is good for learning and visual testing.
 Later we should improve:
 
-- add motion noise, because real odometry is not perfect
 - resample only when needed, not necessarily on every scan
 - improve the laser sensor model
 - publish confidence information, so we know how certain the estimate is

--- a/src/localization/include/localization/particle_filter.hpp
+++ b/src/localization/include/localization/particle_filter.hpp
@@ -18,12 +18,17 @@ public:
 
     void initUniform(const nav_msgs::msg::OccupancyGrid& map);
 
+    void buildLikelihoodField(const nav_msgs::msg::OccupancyGrid& map);
+
     void sampleMotionModel(double old_x, double old_y, double old_theta,
                             double new_x, double new_y, double new_theta);
+
+    const nav_msgs::msg::OccupancyGrid & getLikelihoodFieldMap() const;
     
     const std::vector<Particle> & getParticles() const;
 
 private:
     int num_particles_;
     std::vector<Particle> particles_;
+    nav_msgs::msg::OccupancyGrid likelihood_field_map_;
 };

--- a/src/localization/include/localization/particle_filter.hpp
+++ b/src/localization/include/localization/particle_filter.hpp
@@ -2,13 +2,27 @@
 
 #include <vector>
 #include <cmath>
+#include <random>
 #include "nav_msgs/msg/occupancy_grid.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
 
 struct Particle {
     double x;
     double y;
     double theta;
     double weight;
+};
+
+struct ScanScoreStats {
+    double best_score;
+    double worst_score;
+    double average_score;
+};
+
+struct EstimatedPose {
+    double x;
+    double y;
+    double theta;
 };
 
 class ParticleFilter
@@ -23,12 +37,23 @@ public:
     void sampleMotionModel(double old_x, double old_y, double old_theta,
                             double new_x, double new_y, double new_theta);
 
+    ScanScoreStats scoreParticlesWithScan(const sensor_msgs::msg::LaserScan& scan);
+
+    void resample();
+
+    EstimatedPose estimatePose() const;
+
     const nav_msgs::msg::OccupancyGrid & getLikelihoodFieldMap() const;
     
     const std::vector<Particle> & getParticles() const;
 
 private:
+    bool worldToLikelihoodMap(double x, double y, int & col, int & row) const;
+    double likelihoodAtWorld(double x, double y) const;
+    double normalizeAngle(double angle) const;
+
     int num_particles_;
     std::vector<Particle> particles_;
     nav_msgs::msg::OccupancyGrid likelihood_field_map_;
+    std::default_random_engine rng_;
 };

--- a/src/localization/src/localization_node.cpp
+++ b/src/localization/src/localization_node.cpp
@@ -4,6 +4,7 @@
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "geometry_msgs/msg/pose_array.hpp"
 #include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
@@ -20,6 +21,7 @@ private:
     void scan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
 
     void publish_particles();
+    void publish_estimated_pose();
 
     // Subscriptions
     rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr map_sub_;
@@ -28,6 +30,7 @@ private:
 
     // Publisher
     rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr particle_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr estimated_pose_pub_;
     rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr likelihood_field_pub_;
 
     // State
@@ -58,6 +61,8 @@ LocalizationNode::LocalizationNode()
         std::bind(&LocalizationNode::scan_callback, this, std::placeholders::_1));
 
     particle_pub_ = this->create_publisher<geometry_msgs::msg::PoseArray>("/particlecloud", 10);
+    estimated_pose_pub_ =
+        this->create_publisher<geometry_msgs::msg::PoseStamped>("/estimated_pose", 10);
 
     rclcpp::QoS map_qos(1);
     map_qos.transient_local();
@@ -109,11 +114,26 @@ void LocalizationNode::odom_callback(const nav_msgs::msg::Odometry::SharedPtr ms
     last_odom_theta_ = theta;
 
     publish_particles();
+    publish_estimated_pose();
 }
 
 void LocalizationNode::scan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
 {
-    (void)msg;  // not used yet in v1.0
+    if (!map_received_) return;
+
+    ScanScoreStats stats = pf_.scoreParticlesWithScan(*msg);
+    pf_.resample();
+    publish_particles();
+    publish_estimated_pose();
+
+    RCLCPP_INFO_THROTTLE(
+        this->get_logger(),
+        *this->get_clock(),
+        1000,
+        "Scan scores: best=%.3f average=%.3f worst=%.3f",
+        stats.best_score,
+        stats.average_score,
+        stats.worst_score);
 }
 
 void LocalizationNode::publish_particles()
@@ -133,6 +153,21 @@ void LocalizationNode::publish_particles()
     }
 
     particle_pub_->publish(msg);
+}
+
+void LocalizationNode::publish_estimated_pose()
+{
+    EstimatedPose estimate = pf_.estimatePose();
+
+    geometry_msgs::msg::PoseStamped msg;
+    msg.header.stamp = this->now();
+    msg.header.frame_id = "map";
+    msg.pose.position.x = estimate.x;
+    msg.pose.position.y = estimate.y;
+    msg.pose.orientation.z = std::sin(estimate.theta / 2.0);
+    msg.pose.orientation.w = std::cos(estimate.theta / 2.0);
+
+    estimated_pose_pub_->publish(msg);
 }
 
 int main(int argc, char ** argv)

--- a/src/localization/src/localization_node.cpp
+++ b/src/localization/src/localization_node.cpp
@@ -5,6 +5,12 @@
 #include "geometry_msgs/msg/pose_array.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
@@ -22,6 +28,7 @@ private:
 
     void publish_particles();
     void publish_estimated_pose();
+    void publish_map_to_odom_tf();
 
     // Subscriptions
     rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr map_sub_;
@@ -32,6 +39,11 @@ private:
     rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr particle_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr estimated_pose_pub_;
     rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr likelihood_field_pub_;
+
+    // TF
+    std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+    std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+    std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
     // State
     nav_msgs::msg::OccupancyGrid map_;
@@ -48,6 +60,10 @@ private:
 LocalizationNode::LocalizationNode()
 : Node("localization_node"), pf_(500)   // 500 particles
 {
+    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+    tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
+
     map_sub_ = this->create_subscription<nav_msgs::msg::OccupancyGrid>(
         "/map", 10,
         std::bind(&LocalizationNode::map_callback, this, std::placeholders::_1));
@@ -115,6 +131,7 @@ void LocalizationNode::odom_callback(const nav_msgs::msg::Odometry::SharedPtr ms
 
     publish_particles();
     publish_estimated_pose();
+    publish_map_to_odom_tf();
 }
 
 void LocalizationNode::scan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
@@ -125,6 +142,7 @@ void LocalizationNode::scan_callback(const sensor_msgs::msg::LaserScan::SharedPt
     pf_.resample();
     publish_particles();
     publish_estimated_pose();
+    publish_map_to_odom_tf();
 
     RCLCPP_INFO_THROTTLE(
         this->get_logger(),
@@ -168,6 +186,47 @@ void LocalizationNode::publish_estimated_pose()
     msg.pose.orientation.w = std::cos(estimate.theta / 2.0);
 
     estimated_pose_pub_->publish(msg);
+}
+
+void LocalizationNode::publish_map_to_odom_tf()
+{
+    EstimatedPose estimate = pf_.estimatePose();
+
+    tf2::Quaternion map_to_base_rotation;
+    map_to_base_rotation.setRPY(0.0, 0.0, estimate.theta);
+
+    tf2::Transform map_to_base;
+    map_to_base.setOrigin(tf2::Vector3(estimate.x, estimate.y, 0.0));
+    map_to_base.setRotation(map_to_base_rotation);
+
+    geometry_msgs::msg::TransformStamped odom_to_base_msg;
+    try {
+        odom_to_base_msg = tf_buffer_->lookupTransform(
+            "odom",
+            "base_link",
+            tf2::TimePointZero);
+    } catch (const tf2::TransformException & ex) {
+        RCLCPP_WARN_THROTTLE(
+            this->get_logger(),
+            *this->get_clock(),
+            1000,
+            "Could not publish map->odom TF: %s",
+            ex.what());
+        return;
+    }
+
+    tf2::Transform odom_to_base;
+    tf2::fromMsg(odom_to_base_msg.transform, odom_to_base);
+
+    tf2::Transform map_to_odom = map_to_base * odom_to_base.inverse();
+
+    geometry_msgs::msg::TransformStamped map_to_odom_msg;
+    map_to_odom_msg.header.stamp = odom_to_base_msg.header.stamp;
+    map_to_odom_msg.header.frame_id = "map";
+    map_to_odom_msg.child_frame_id = "odom";
+    map_to_odom_msg.transform = tf2::toMsg(map_to_odom);
+
+    tf_broadcaster_->sendTransform(map_to_odom_msg);
 }
 
 int main(int argc, char ** argv)

--- a/src/localization/src/localization_node.cpp
+++ b/src/localization/src/localization_node.cpp
@@ -53,6 +53,7 @@ private:
     double last_odom_y_     = 0.0;
     double last_odom_theta_ = 0.0;
     bool   odom_initialized_ = false;
+    bool   particles_moved_since_last_resample_ = false;
 
     ParticleFilter pf_;
 };
@@ -124,6 +125,7 @@ void LocalizationNode::odom_callback(const nav_msgs::msg::Odometry::SharedPtr ms
     if (std::abs(dx) < 0.001 && std::abs(dy) < 0.001 && std::abs(dtheta) < 0.001) return;
 
     pf_.sampleMotionModel(last_odom_x_, last_odom_y_, last_odom_theta_, x, y, theta);
+    particles_moved_since_last_resample_ = true;
 
     last_odom_x_     = x;
     last_odom_y_     = y;
@@ -139,7 +141,10 @@ void LocalizationNode::scan_callback(const sensor_msgs::msg::LaserScan::SharedPt
     if (!map_received_) return;
 
     ScanScoreStats stats = pf_.scoreParticlesWithScan(*msg);
-    pf_.resample();
+    if (particles_moved_since_last_resample_) {
+        pf_.resample();
+        particles_moved_since_last_resample_ = false;
+    }
     publish_particles();
     publish_estimated_pose();
     publish_map_to_odom_tf();

--- a/src/localization/src/localization_node.cpp
+++ b/src/localization/src/localization_node.cpp
@@ -28,6 +28,7 @@ private:
 
     // Publisher
     rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr particle_pub_;
+    rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr likelihood_field_pub_;
 
     // State
     nav_msgs::msg::OccupancyGrid map_;
@@ -58,6 +59,12 @@ LocalizationNode::LocalizationNode()
 
     particle_pub_ = this->create_publisher<geometry_msgs::msg::PoseArray>("/particlecloud", 10);
 
+    rclcpp::QoS map_qos(1);
+    map_qos.transient_local();
+    map_qos.reliable();
+    likelihood_field_pub_ =
+        this->create_publisher<nav_msgs::msg::OccupancyGrid>("/likelihood_field", map_qos);
+
     RCLCPP_INFO(this->get_logger(), "LocalizationNode started.");
 }
 
@@ -65,9 +72,12 @@ void LocalizationNode::map_callback(const nav_msgs::msg::OccupancyGrid::SharedPt
 {
     map_ = *msg;
     map_received_ = true;
+    pf_.buildLikelihoodField(map_);
     pf_.initUniform(map_);
+    likelihood_field_pub_->publish(pf_.getLikelihoodFieldMap());
     RCLCPP_INFO(this->get_logger(),
-        "Map received: %d x %d cells. Particles initialised.", msg->info.width, msg->info.height);
+        "Map received: %d x %d cells. Likelihood field built. Particles initialised.",
+        msg->info.width, msg->info.height);
 }
 
 void LocalizationNode::odom_callback(const nav_msgs::msg::Odometry::SharedPtr msg)

--- a/src/localization/src/particle_filter.cpp
+++ b/src/localization/src/particle_filter.cpp
@@ -1,4 +1,6 @@
 #include "localization/particle_filter.hpp"
+#include <algorithm>
+#include <queue>
 #include <random>
 #include <cmath>
 
@@ -44,6 +46,80 @@ void ParticleFilter::initUniform(const nav_msgs::msg::OccupancyGrid & map)
     }
 }
 
+void ParticleFilter::buildLikelihoodField(const nav_msgs::msg::OccupancyGrid & map)
+{
+    likelihood_field_map_ = map;
+
+    int width = map.info.width;
+    int height = map.info.height;
+    int total_cells = width * height;
+    double resolution = map.info.resolution;
+
+    double max_distance_m = 1.0;
+    int max_distance_cells = static_cast<int>(std::ceil(max_distance_m / resolution));
+
+    // Distance starts as "far from wall".
+    // Later, wall cells spread smaller distance values to their neighbors.
+    std::vector<int> distance_to_wall(total_cells, max_distance_cells);
+    std::queue<int> cells_to_visit;
+
+    for (int i = 0; i < total_cells; ++i) {
+        if (map.data[i] > 50) {
+            distance_to_wall[i] = 0;
+            cells_to_visit.push(i);
+        }
+    }
+
+    const int neighbor_offsets[4][2] = {
+        {1, 0},
+        {-1, 0},
+        {0, 1},
+        {0, -1}
+    };
+
+    // This is like dropping ink on all wall cells.
+    // The ink spreads one cell at a time into nearby free cells.
+    while (!cells_to_visit.empty()) {
+        int index = cells_to_visit.front();
+        cells_to_visit.pop();
+
+        int row = index / width;
+        int col = index % width;
+        int next_distance = distance_to_wall[index] + 1;
+
+        if (next_distance > max_distance_cells) {
+            continue;
+        }
+
+        for (const auto & offset : neighbor_offsets) {
+            int next_col = col + offset[0];
+            int next_row = row + offset[1];
+
+            if (next_col < 0 || next_row < 0 || next_col >= width || next_row >= height) {
+                continue;
+            }
+
+            int next_index = next_row * width + next_col;
+            if (next_distance >= distance_to_wall[next_index]) {
+                continue;
+            }
+
+            distance_to_wall[next_index] = next_distance;
+            cells_to_visit.push(next_index);
+        }
+    }
+
+    likelihood_field_map_.data.assign(total_cells, 0);
+
+    for (int i = 0; i < total_cells; ++i) {
+        double distance_m = distance_to_wall[i] * resolution;
+        double likelihood = 1.0 - std::min(distance_m / max_distance_m, 1.0);
+
+        likelihood_field_map_.data[i] =
+            static_cast<int8_t>(std::round(likelihood * 100.0));
+    }
+}
+
 void ParticleFilter::sampleMotionModel(
     double old_x, double old_y, double old_theta,
     double new_x, double new_y, double new_theta)
@@ -67,4 +143,9 @@ void ParticleFilter::sampleMotionModel(
 const std::vector<Particle> & ParticleFilter::getParticles() const
 {
     return particles_;
+}
+
+const nav_msgs::msg::OccupancyGrid & ParticleFilter::getLikelihoodFieldMap() const
+{
+    return likelihood_field_map_;
 }

--- a/src/localization/src/particle_filter.cpp
+++ b/src/localization/src/particle_filter.cpp
@@ -132,11 +132,22 @@ void ParticleFilter::sampleMotionModel(
     double delta_trans = std::sqrt(std::pow(new_x - old_x, 2) + std::pow(new_y - old_y, 2));
     double delta_rot2  = new_theta - old_theta - delta_rot1;
 
-    // Apply the exact same delta to every particle (v1.0: zero noise)
+    double trans_noise_std = 0.02 * delta_trans + 0.005;
+    double rot1_noise_std = 0.05 * std::abs(delta_rot1) + 0.01 * delta_trans + 0.002;
+    double rot2_noise_std = 0.05 * std::abs(delta_rot2) + 0.01 * delta_trans + 0.002;
+
+    std::normal_distribution<double> trans_noise(0.0, trans_noise_std);
+    std::normal_distribution<double> rot1_noise(0.0, rot1_noise_std);
+    std::normal_distribution<double> rot2_noise(0.0, rot2_noise_std);
+
     for (auto & p : particles_) {
-        p.x     += delta_trans * std::cos(p.theta + delta_rot1);
-        p.y     += delta_trans * std::sin(p.theta + delta_rot1);
-        p.theta += delta_rot1 + delta_rot2;
+        double noisy_rot1 = delta_rot1 + rot1_noise(rng_);
+        double noisy_trans = delta_trans + trans_noise(rng_);
+        double noisy_rot2 = delta_rot2 + rot2_noise(rng_);
+
+        p.x     += noisy_trans * std::cos(p.theta + noisy_rot1);
+        p.y     += noisy_trans * std::sin(p.theta + noisy_rot1);
+        p.theta = normalizeAngle(p.theta + noisy_rot1 + noisy_rot2);
     }
 }
 

--- a/src/localization/src/particle_filter.cpp
+++ b/src/localization/src/particle_filter.cpp
@@ -1,11 +1,12 @@
 #include "localization/particle_filter.hpp"
 #include <algorithm>
+#include <limits>
 #include <queue>
 #include <random>
 #include <cmath>
 
 ParticleFilter::ParticleFilter(int num_particles)
-    : num_particles_(num_particles)
+    : num_particles_(num_particles), rng_(42)
 {
     particles_.resize(num_particles_);
 }
@@ -20,15 +21,14 @@ void ParticleFilter::initUniform(const nav_msgs::msg::OccupancyGrid & map)
     double orig_y = map.info.origin.position.y;
 
     // Random number generators
-    std::default_random_engine rng(42);  // 42 = fixed seed, so results are repeatable
     std::uniform_int_distribution<int> rand_col(0, width - 1);
     std::uniform_int_distribution<int> rand_row(0, height - 1);
     std::uniform_real_distribution<double> rand_theta(-M_PI, M_PI);
 
     int placed = 0;
     while (placed < num_particles_) {
-        int col = rand_col(rng);
-        int row = rand_row(rng);
+        int col = rand_col(rng_);
+        int row = rand_row(rng_);
 
         // map.data is a flat array: index = row * width + col
         // value 0 = free, 100 = occupied, -1 = unknown
@@ -40,7 +40,7 @@ void ParticleFilter::initUniform(const nav_msgs::msg::OccupancyGrid & map)
         // Convert grid cell back to world coordinates
         particles_[placed].x     = orig_x + (col + 0.5) * res;
         particles_[placed].y     = orig_y + (row + 0.5) * res;
-        particles_[placed].theta = rand_theta(rng);
+        particles_[placed].theta = rand_theta(rng_);
         particles_[placed].weight = 1.0 / num_particles_;
         placed++;
     }
@@ -140,6 +140,146 @@ void ParticleFilter::sampleMotionModel(
     }
 }
 
+ScanScoreStats ParticleFilter::scoreParticlesWithScan(const sensor_msgs::msg::LaserScan & scan)
+{
+    ScanScoreStats stats;
+    stats.best_score = 0.0;
+    stats.worst_score = std::numeric_limits<double>::max();
+    stats.average_score = 0.0;
+
+    if (likelihood_field_map_.data.empty()) {
+        return stats;
+    }
+
+    const size_t beam_step = 10;
+    double score_sum = 0.0;
+
+    for (auto & p : particles_) {
+        double particle_score = 0.0;
+        int used_beams = 0;
+
+        for (size_t i = 0; i < scan.ranges.size(); i += beam_step) {
+            float range = scan.ranges[i];
+
+            if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
+                continue;
+            }
+
+            double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
+            double hit_x = p.x + range * std::cos(p.theta + beam_angle);
+            double hit_y = p.y + range * std::sin(p.theta + beam_angle);
+
+            particle_score += likelihoodAtWorld(hit_x, hit_y);
+            used_beams++;
+        }
+
+        if (used_beams > 0) {
+            particle_score /= used_beams;
+        }
+
+        p.weight = particle_score;
+        score_sum += particle_score;
+        stats.best_score = std::max(stats.best_score, particle_score);
+        stats.worst_score = std::min(stats.worst_score, particle_score);
+    }
+
+    stats.average_score = score_sum / particles_.size();
+
+    if (stats.worst_score == std::numeric_limits<double>::max()) {
+        stats.worst_score = 0.0;
+    }
+
+    return stats;
+}
+
+void ParticleFilter::resample()
+{
+    double weight_sum = 0.0;
+    for (const auto & p : particles_) {
+        weight_sum += p.weight;
+    }
+
+    if (weight_sum <= 0.0 || !std::isfinite(weight_sum)) {
+        double equal_weight = 1.0 / num_particles_;
+        for (auto & p : particles_) {
+            p.weight = equal_weight;
+        }
+        return;
+    }
+
+    std::vector<double> cumulative_weights;
+    cumulative_weights.reserve(particles_.size());
+    double cumulative_sum = 0.0;
+
+    for (auto & p : particles_) {
+        p.weight /= weight_sum;
+        cumulative_sum += p.weight;
+        cumulative_weights.push_back(cumulative_sum);
+    }
+
+    // Avoid tiny floating-point error, so the final pointer can always find a particle.
+    cumulative_weights.back() = 1.0;
+
+    std::normal_distribution<double> xy_noise(0.0, 0.02);
+    std::normal_distribution<double> theta_noise(0.0, 0.03);
+    std::uniform_real_distribution<double> start_distribution(0.0, 1.0 / num_particles_);
+
+    std::vector<Particle> new_particles;
+    new_particles.reserve(num_particles_);
+
+    double pointer = start_distribution(rng_);
+    double step = 1.0 / num_particles_;
+    size_t particle_index = 0;
+
+    for (int i = 0; i < num_particles_; ++i) {
+        while (pointer > cumulative_weights[particle_index]) {
+            particle_index++;
+        }
+
+        Particle copied = particles_[particle_index];
+
+        copied.x += xy_noise(rng_);
+        copied.y += xy_noise(rng_);
+        copied.theta = normalizeAngle(copied.theta + theta_noise(rng_));
+        copied.weight = 1.0 / num_particles_;
+
+        new_particles.push_back(copied);
+        pointer += step;
+    }
+
+    particles_ = new_particles;
+}
+
+EstimatedPose ParticleFilter::estimatePose() const
+{
+    EstimatedPose pose;
+    pose.x = 0.0;
+    pose.y = 0.0;
+    pose.theta = 0.0;
+
+    if (particles_.empty()) {
+        return pose;
+    }
+
+    double sum_x = 0.0;
+    double sum_y = 0.0;
+    double sum_sin = 0.0;
+    double sum_cos = 0.0;
+
+    for (const auto & p : particles_) {
+        sum_x += p.x;
+        sum_y += p.y;
+        sum_sin += std::sin(p.theta);
+        sum_cos += std::cos(p.theta);
+    }
+
+    pose.x = sum_x / particles_.size();
+    pose.y = sum_y / particles_.size();
+    pose.theta = std::atan2(sum_sin, sum_cos);
+
+    return pose;
+}
+
 const std::vector<Particle> & ParticleFilter::getParticles() const
 {
     return particles_;
@@ -148,4 +288,46 @@ const std::vector<Particle> & ParticleFilter::getParticles() const
 const nav_msgs::msg::OccupancyGrid & ParticleFilter::getLikelihoodFieldMap() const
 {
     return likelihood_field_map_;
+}
+
+bool ParticleFilter::worldToLikelihoodMap(double x, double y, int & col, int & row) const
+{
+    if (likelihood_field_map_.data.empty()) {
+        return false;
+    }
+
+    double resolution = likelihood_field_map_.info.resolution;
+    double origin_x = likelihood_field_map_.info.origin.position.x;
+    double origin_y = likelihood_field_map_.info.origin.position.y;
+
+    col = static_cast<int>(std::floor((x - origin_x) / resolution));
+    row = static_cast<int>(std::floor((y - origin_y) / resolution));
+
+    return col >= 0 &&
+        row >= 0 &&
+        col < static_cast<int>(likelihood_field_map_.info.width) &&
+        row < static_cast<int>(likelihood_field_map_.info.height);
+}
+
+double ParticleFilter::likelihoodAtWorld(double x, double y) const
+{
+    int col = 0;
+    int row = 0;
+    if (!worldToLikelihoodMap(x, y, col, row)) {
+        return 0.0;
+    }
+
+    int index = row * likelihood_field_map_.info.width + col;
+    return likelihood_field_map_.data[index] / 100.0;
+}
+
+double ParticleFilter::normalizeAngle(double angle) const
+{
+    while (angle > M_PI) {
+        angle -= 2.0 * M_PI;
+    }
+    while (angle < -M_PI) {
+        angle += 2.0 * M_PI;
+    }
+    return angle;
 }


### PR DESCRIPTION
## Summary

This PR adds the first working particle-filter localization pipeline.

The localization package now:

- builds and publishes a likelihood field from `/map`
- initializes particles on free map cells
- updates particles using `/odom` with small motion noise
- scores particles using `/scan`
- resamples particles with stochastic universal resampling
- only resamples after odometry has moved the particles
- publishes `/particlecloud`
- publishes `/estimated_pose`
- publishes the standard ROS `map -> odom` transform

The root README and localization README were updated to describe the current workflow and remove the old static `map -> odom` step.

## Why

The previous localization package only initialized and moved particles with odometry. It did not use laser scans, resampling, an estimated pose output, or the `map -> odom` TF needed for normal ROS localization behavior.

This PR makes localization usable in RViz and gives later navigation work the expected TF chain:

```text
map -> odom -> base_link
```

## Testing

Tested locally with:

```bash
colcon build --packages-select localization
```

Also tested in Gazebo/RViz:

- `/likelihood_field` publishes and can be visualized
- particles converge near the robot
- `/estimated_pose` appears near the particle cloud center
- `tf2_echo map base_link` works through `map -> odom -> base_link`
- movement-based resampling avoids repeatedly shrinking the particle cloud while the robot is standing still

## Later Work

Future improvements can include:

- effective sample size based resampling
- improved laser sensor model
- confidence/debug output
- ROS parameters for particle count, beam step, noise, and resampling behavior
