### PR TITLE
Add Kalman localization node

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ Simple meaning:
 
 ### `localization`
 
-This package is the completed first localization stage.
+This package contains learning localization nodes.
 
-It runs a first working particle filter localizer.
+It includes a first working particle-filter localizer and a simple Kalman-filter pose tracker.
 
-It reads:
+The particle-filter node reads:
 
 - `/map`
 - `/odom`
@@ -79,6 +79,9 @@ The particle filter:
 - scores particles using laser scans
 - resamples after robot movement
 - publishes the estimated pose and the normal ROS `map -> odom` transform
+
+The Kalman-filter node assumes a known initial pose of `0, 0, 0`.
+It reads `/odom` and publishes `/estimated_pose`, `/estimated_pose_with_covariance`, and `map -> odom`.
 
 ## Quick Start
 
@@ -185,10 +188,10 @@ Activate the lifecycle node:
 ros2 run nav2_util lifecycle_bringup map_server
 ```
 
-### 5. Start localization
+### 5. Start particle-filter localization
 
 ```bash
-ros2 run localization localization_node
+ros2 run localization particle_filter_localization_node
 ```
 
 In RViz:
@@ -206,6 +209,14 @@ The `/estimated_pose` topic shows the current best pose estimate.
 Do not run a static `map -> odom` transform during localization.
 The localization node publishes `map -> odom`.
 
+To run the Kalman-filter node instead:
+
+```bash
+ros2 run localization kalman_localization_node
+```
+
+Do not run both localization nodes at the same time.
+
 ## Project Structure
 
 ```text
@@ -221,7 +232,5 @@ gazebo_ws/
 
 - Simulation works.
 - Mapping works as a basic occupancy grid mapper.
-- Localization first version is complete.
-- Localization uses a particle filter with a likelihood field, laser scan scoring, motion noise, and resampling.
-- Localization publishes `/particlecloud`, `/likelihood_field`, `/estimated_pose`, and `map -> odom`.
-- Future localization improvements can include better scan scoring, confidence output, and more tuning.
+- Localization includes a particle-filter node with likelihood-field scan scoring.
+- Localization includes a simple prediction-only Kalman-filter node with covariance output.

--- a/src/localization/CMakeLists.txt
+++ b/src/localization/CMakeLists.txt
@@ -28,18 +28,27 @@ if(BUILD_TESTING)
 endif()
 
 # 1. tell cmake which source file to complile into executable
-add_executable(localization_node 
-  src/localization_node.cpp
+add_executable(particle_filter_localization_node 
+  src/particle_filter_localization_node.cpp
   src/particle_filter.cpp
 )
 
+add_executable(kalman_localization_node
+  src/kalman_localization_node.cpp
+  src/kalman_filter.cpp
+)
+
 # 1. tell cmake where to find header files
-target_include_directories(localization_node PUBLIC
+target_include_directories(particle_filter_localization_node PUBLIC
+  include
+)
+
+target_include_directories(kalman_localization_node PUBLIC
   include
 )
 
 # 2. link dependecies to executable
-ament_target_dependencies(localization_node
+ament_target_dependencies(particle_filter_localization_node
   rclcpp
   sensor_msgs
   nav_msgs
@@ -49,9 +58,19 @@ ament_target_dependencies(localization_node
   tf2_geometry_msgs
 )
 
+ament_target_dependencies(kalman_localization_node
+  rclcpp
+  nav_msgs
+  geometry_msgs
+  tf2
+  tf2_ros
+  tf2_geometry_msgs
+)
+
 # 3. copy compile binary to install/ , ros2 run can find it
 install(TARGETS
-  localization_node
+  particle_filter_localization_node
+  kalman_localization_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/src/localization/README.md
+++ b/src/localization/README.md
@@ -6,7 +6,17 @@ The goal is to estimate where the robot is on a known map.
 
 ## Current Situation
 
-The package has a first particle filter.
+The package has two learning localization nodes:
+
+- `particle_filter_localization_node`: a first particle-filter localizer using `/map`, `/odom`, and `/scan`
+- `kalman_localization_node`: a first Kalman-filter pose tracker using `/odom`
+
+Do not run both nodes at the same time.
+Both publish `/estimated_pose` and the `map -> odom` transform.
+
+## Particle Filter Node
+
+The particle-filter node is the first map-based localization version.
 
 Right now it can:
 
@@ -21,12 +31,11 @@ Right now it can:
 - publish one estimated robot pose on `/estimated_pose`
 - publish the `map -> odom` transform
 
-So this is now a working first particle-filter localization version.
 It can localize visually in RViz and publish the normal ROS localization TF.
 
-## Topics
+### Particle Filter Topics
 
-The localization node subscribes to:
+The particle-filter node subscribes to:
 
 - `/map`
 - `/odom`
@@ -59,6 +68,38 @@ Together they form:
 ```text
 map -> odom -> base_link
 ```
+
+## Kalman Filter Node
+
+The Kalman-filter node is a simpler learning version.
+It assumes the robot starts from a known initial pose:
+
+```text
+x = 0
+y = 0
+theta = 0
+```
+
+It subscribes to:
+
+- `/odom`
+
+It publishes:
+
+- `/estimated_pose`
+- `/estimated_pose_with_covariance`
+- TF: `map -> odom`
+
+This version is prediction-only.
+It uses odometry deltas to update `[x, y, theta]`.
+It also grows a covariance matrix to show increasing uncertainty as the robot moves.
+
+The covariance grows only when odometry changes more than a small threshold.
+This keeps the covariance from growing while the robot is standing still.
+
+This node does not use `/map` or `/scan` yet.
+It is not global localization.
+It is a local pose tracker from a known starting pose.
 
 ## Build
 
@@ -102,14 +143,14 @@ Terminal 5:
 ros2 run nav2_util lifecycle_bringup map_server
 ```
 
-Terminal 6:
+Terminal 6, particle-filter localization:
 
 ```bash
-ros2 run localization localization_node
+ros2 run localization particle_filter_localization_node
 ```
 
 Do not run the old static `map -> odom` transform.
-The localization node now publishes `map -> odom`.
+The localization node publishes `map -> odom`.
 If two nodes publish the same transform, TF can become confused.
 
 In RViz:
@@ -123,6 +164,19 @@ In RViz:
 Then drive the robot with teleop.
 You should see the particles move and converge near the robot.
 You should also see `/estimated_pose` near the center of the particle cloud.
+
+To run the Kalman-filter node instead:
+
+```bash
+ros2 run localization kalman_localization_node
+```
+
+In RViz, add:
+
+- `/estimated_pose`
+- `/estimated_pose_with_covariance`
+
+Do not run the particle-filter node and Kalman-filter node together.
 
 ## How It Works
 

--- a/src/localization/include/localization/kalman_filter.hpp
+++ b/src/localization/include/localization/kalman_filter.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <array>
+
+struct KalmanFilterParameters {
+    double initial_std_x = 0.02;
+    double initial_std_y = 0.02;
+    double initial_std_theta = 0.02;
+
+    double base_process_std_x = 0.005;
+    double base_process_std_y = 0.005;
+    double base_process_std_theta = 0.002;
+
+    double distance_noise_scale = 0.10;
+    double rotation_noise_scale = 0.10;
+
+    double min_translation_delta = 0.001;
+    double min_rotation_delta = 0.001;
+};
+
+struct KalmanPose {
+    double x;
+    double y;
+    double theta;
+};
+
+class KalmanFilter
+{
+public:
+    using Matrix3x3 = std::array<double, 9>;
+
+    explicit KalmanFilter(const KalmanFilterParameters & parameters = KalmanFilterParameters());
+
+    void initialize(double x, double y, double theta);
+
+    void predictFromOdometry(
+        double old_x, double old_y, double old_theta,
+        double new_x, double new_y, double new_theta);
+
+    bool isInitialized() const;
+
+    KalmanPose estimatePose() const;
+
+    const Matrix3x3 & covariance() const;
+
+private:
+    Matrix3x3 makeInitialCovariance() const;
+    Matrix3x3 makeProcessNoise(double distance, double rotation) const;
+    double normalizeAngle(double angle) const;
+    double square(double value) const;
+
+    KalmanFilterParameters parameters_;
+    KalmanPose state_;
+    Matrix3x3 covariance_;
+    bool initialized_;
+};

--- a/src/localization/package.xml
+++ b/src/localization/package.xml
@@ -13,6 +13,7 @@
   <depend>sensor_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
 

--- a/src/localization/src/kalman_filter.cpp
+++ b/src/localization/src/kalman_filter.cpp
@@ -1,0 +1,107 @@
+#include "localization/kalman_filter.hpp"
+
+#include <cmath>
+
+KalmanFilter::KalmanFilter(const KalmanFilterParameters & parameters)
+: parameters_(parameters),
+  state_{0.0, 0.0, 0.0},
+  covariance_{},
+  initialized_(false)
+{
+}
+
+void KalmanFilter::initialize(double x, double y, double theta)
+{
+    state_.x = x;
+    state_.y = y;
+    state_.theta = normalizeAngle(theta);
+    covariance_ = makeInitialCovariance();
+    initialized_ = true;
+}
+
+void KalmanFilter::predictFromOdometry(
+    double old_x, double old_y, double old_theta,
+    double new_x, double new_y, double new_theta)
+{
+    if (!initialized_) {
+        return;
+    }
+
+    double dx = new_x - old_x;
+    double dy = new_y - old_y;
+    double dtheta = normalizeAngle(new_theta - old_theta);
+    double distance = std::sqrt(dx * dx + dy * dy);
+    double rotation = std::abs(dtheta);
+
+    if (distance < parameters_.min_translation_delta &&
+        rotation < parameters_.min_rotation_delta) {
+        return;
+    }
+
+    state_.x += dx;
+    state_.y += dy;
+    state_.theta = normalizeAngle(state_.theta + dtheta);
+
+    Matrix3x3 process_noise = makeProcessNoise(distance, rotation);
+
+    for (std::size_t i = 0; i < covariance_.size(); ++i) {
+        covariance_[i] += process_noise[i];
+    }
+}
+
+bool KalmanFilter::isInitialized() const
+{
+    return initialized_;
+}
+
+KalmanPose KalmanFilter::estimatePose() const
+{
+    return state_;
+}
+
+const KalmanFilter::Matrix3x3 & KalmanFilter::covariance() const
+{
+    return covariance_;
+}
+
+KalmanFilter::Matrix3x3 KalmanFilter::makeInitialCovariance() const
+{
+    return {
+        square(parameters_.initial_std_x), 0.0, 0.0,
+        0.0, square(parameters_.initial_std_y), 0.0,
+        0.0, 0.0, square(parameters_.initial_std_theta)
+    };
+}
+
+KalmanFilter::Matrix3x3 KalmanFilter::makeProcessNoise(
+    double distance, double rotation) const
+{
+    double std_x =
+        parameters_.base_process_std_x + parameters_.distance_noise_scale * distance;
+    double std_y =
+        parameters_.base_process_std_y + parameters_.distance_noise_scale * distance;
+    double std_theta =
+        parameters_.base_process_std_theta + parameters_.rotation_noise_scale * rotation;
+
+    return {
+        square(std_x), 0.0, 0.0,
+        0.0, square(std_y), 0.0,
+        0.0, 0.0, square(std_theta)
+    };
+}
+
+double KalmanFilter::normalizeAngle(double angle) const
+{
+    while (angle > M_PI) {
+        angle -= 2.0 * M_PI;
+    }
+    while (angle < -M_PI) {
+        angle += 2.0 * M_PI;
+    }
+    return angle;
+}
+
+double KalmanFilter::square(double value) const
+{
+    return value * value;
+}

--- a/src/localization/src/kalman_localization_node.cpp
+++ b/src/localization/src/kalman_localization_node.cpp
@@ -1,0 +1,186 @@
+#include "rclcpp/rclcpp.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+
+#include <cmath>
+#include <memory>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2/utils.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_ros/transform_broadcaster.h>
+
+#include "localization/kalman_filter.hpp"
+
+class KalmanLocalizationNode : public rclcpp::Node
+{
+public:
+    KalmanLocalizationNode();
+
+private:
+    void odom_callback(const nav_msgs::msg::Odometry::SharedPtr msg);
+
+    void publish_estimated_pose();
+    void publish_estimated_pose_with_covariance();
+    void publish_map_to_odom_tf(
+        double odom_x, double odom_y, double odom_theta,
+        const rclcpp::Time & stamp);
+    geometry_msgs::msg::Quaternion yaw_to_quaternion(double yaw) const;
+
+    rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr estimated_pose_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
+        estimated_pose_with_covariance_pub_;
+    std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+
+    KalmanFilter kf_;
+
+    double last_odom_x_ = 0.0;
+    double last_odom_y_ = 0.0;
+    double last_odom_theta_ = 0.0;
+    bool odom_initialized_ = false;
+};
+
+KalmanLocalizationNode::KalmanLocalizationNode()
+: Node("kalman_localization_node")
+{
+    kf_.initialize(0.0, 0.0, 0.0);
+    tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
+
+    odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+        "/odom", 10,
+        std::bind(&KalmanLocalizationNode::odom_callback, this, std::placeholders::_1));
+
+    estimated_pose_pub_ =
+        this->create_publisher<geometry_msgs::msg::PoseStamped>("/estimated_pose", 10);
+    estimated_pose_with_covariance_pub_ =
+        this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
+            "/estimated_pose_with_covariance", 10);
+
+    RCLCPP_INFO(
+        this->get_logger(),
+        "KalmanLocalizationNode started with initial pose x=0.0 y=0.0 theta=0.0.");
+}
+
+void KalmanLocalizationNode::odom_callback(const nav_msgs::msg::Odometry::SharedPtr msg)
+{
+    double x = msg->pose.pose.position.x;
+    double y = msg->pose.pose.position.y;
+    double theta = tf2::getYaw(msg->pose.pose.orientation);
+
+    if (!odom_initialized_) {
+        last_odom_x_ = x;
+        last_odom_y_ = y;
+        last_odom_theta_ = theta;
+        odom_initialized_ = true;
+
+        publish_estimated_pose();
+        publish_estimated_pose_with_covariance();
+        publish_map_to_odom_tf(x, y, theta, msg->header.stamp);
+        return;
+    }
+
+    kf_.predictFromOdometry(last_odom_x_, last_odom_y_, last_odom_theta_, x, y, theta);
+
+    last_odom_x_ = x;
+    last_odom_y_ = y;
+    last_odom_theta_ = theta;
+
+    publish_estimated_pose();
+    publish_estimated_pose_with_covariance();
+    publish_map_to_odom_tf(x, y, theta, msg->header.stamp);
+}
+
+void KalmanLocalizationNode::publish_estimated_pose()
+{
+    KalmanPose estimate = kf_.estimatePose();
+
+    geometry_msgs::msg::PoseStamped msg;
+    msg.header.stamp = this->now();
+    msg.header.frame_id = "map";
+    msg.pose.position.x = estimate.x;
+    msg.pose.position.y = estimate.y;
+    msg.pose.orientation = yaw_to_quaternion(estimate.theta);
+
+    estimated_pose_pub_->publish(msg);
+}
+
+void KalmanLocalizationNode::publish_estimated_pose_with_covariance()
+{
+    KalmanPose estimate = kf_.estimatePose();
+    const auto & covariance = kf_.covariance();
+
+    geometry_msgs::msg::PoseWithCovarianceStamped msg;
+    msg.header.stamp = this->now();
+    msg.header.frame_id = "map";
+    msg.pose.pose.position.x = estimate.x;
+    msg.pose.pose.position.y = estimate.y;
+    msg.pose.pose.orientation = yaw_to_quaternion(estimate.theta);
+
+    msg.pose.covariance[0] = covariance[0];
+    msg.pose.covariance[1] = covariance[1];
+    msg.pose.covariance[5] = covariance[2];
+    msg.pose.covariance[6] = covariance[3];
+    msg.pose.covariance[7] = covariance[4];
+    msg.pose.covariance[11] = covariance[5];
+    msg.pose.covariance[30] = covariance[6];
+    msg.pose.covariance[31] = covariance[7];
+    msg.pose.covariance[35] = covariance[8];
+
+    estimated_pose_with_covariance_pub_->publish(msg);
+}
+
+void KalmanLocalizationNode::publish_map_to_odom_tf(
+    double odom_x, double odom_y, double odom_theta,
+    const rclcpp::Time & stamp)
+{
+    KalmanPose estimate = kf_.estimatePose();
+
+    tf2::Quaternion map_to_base_rotation;
+    map_to_base_rotation.setRPY(0.0, 0.0, estimate.theta);
+
+    tf2::Transform map_to_base;
+    map_to_base.setOrigin(tf2::Vector3(estimate.x, estimate.y, 0.0));
+    map_to_base.setRotation(map_to_base_rotation);
+
+    tf2::Quaternion odom_to_base_rotation;
+    odom_to_base_rotation.setRPY(0.0, 0.0, odom_theta);
+
+    tf2::Transform odom_to_base;
+    odom_to_base.setOrigin(tf2::Vector3(odom_x, odom_y, 0.0));
+    odom_to_base.setRotation(odom_to_base_rotation);
+
+    tf2::Transform map_to_odom = map_to_base * odom_to_base.inverse();
+
+    geometry_msgs::msg::TransformStamped msg;
+    msg.header.stamp = stamp;
+    msg.header.frame_id = "map";
+    msg.child_frame_id = "odom";
+    msg.transform = tf2::toMsg(map_to_odom);
+
+    tf_broadcaster_->sendTransform(msg);
+}
+
+geometry_msgs::msg::Quaternion KalmanLocalizationNode::yaw_to_quaternion(double yaw) const
+{
+    tf2::Quaternion quaternion;
+    quaternion.setRPY(0.0, 0.0, yaw);
+
+    geometry_msgs::msg::Quaternion msg;
+    msg.x = quaternion.x();
+    msg.y = quaternion.y();
+    msg.z = quaternion.z();
+    msg.w = quaternion.w();
+    return msg;
+}
+
+int main(int argc, char ** argv)
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<KalmanLocalizationNode>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/localization/src/particle_filter_localization_node.cpp
+++ b/src/localization/src/particle_filter_localization_node.cpp
@@ -16,10 +16,10 @@
 
 #include "localization/particle_filter.hpp"
 
-class LocalizationNode : public rclcpp::Node
+class ParticleFilterLocalizationNode : public rclcpp::Node
 {
 public:
-    LocalizationNode();
+    ParticleFilterLocalizationNode();
 
 private:
     void map_callback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg);
@@ -58,8 +58,8 @@ private:
     ParticleFilter pf_;
 };
 
-LocalizationNode::LocalizationNode()
-: Node("localization_node"), pf_(500)   // 500 particles
+ParticleFilterLocalizationNode::ParticleFilterLocalizationNode()
+: Node("particle_filter_localization_node"), pf_(500)   // 500 particles
 {
     tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
@@ -71,15 +71,15 @@ LocalizationNode::LocalizationNode()
 
     map_sub_ = this->create_subscription<nav_msgs::msg::OccupancyGrid>(
         "/map", static_map_qos,
-        std::bind(&LocalizationNode::map_callback, this, std::placeholders::_1));
+        std::bind(&ParticleFilterLocalizationNode::map_callback, this, std::placeholders::_1));
 
     odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
         "/odom", 10,
-        std::bind(&LocalizationNode::odom_callback, this, std::placeholders::_1));
+        std::bind(&ParticleFilterLocalizationNode::odom_callback, this, std::placeholders::_1));
 
     scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>(
         "/scan", 10,
-        std::bind(&LocalizationNode::scan_callback, this, std::placeholders::_1));
+        std::bind(&ParticleFilterLocalizationNode::scan_callback, this, std::placeholders::_1));
 
     particle_pub_ = this->create_publisher<geometry_msgs::msg::PoseArray>("/particlecloud", 10);
     estimated_pose_pub_ =
@@ -88,10 +88,10 @@ LocalizationNode::LocalizationNode()
     likelihood_field_pub_ =
         this->create_publisher<nav_msgs::msg::OccupancyGrid>("/likelihood_field", static_map_qos);
 
-    RCLCPP_INFO(this->get_logger(), "LocalizationNode started.");
+    RCLCPP_INFO(this->get_logger(), "ParticleFilterLocalizationNode started.");
 }
 
-void LocalizationNode::map_callback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg)
+void ParticleFilterLocalizationNode::map_callback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg)
 {
     map_ = *msg;
     map_received_ = true;
@@ -103,7 +103,7 @@ void LocalizationNode::map_callback(const nav_msgs::msg::OccupancyGrid::SharedPt
         msg->info.width, msg->info.height);
 }
 
-void LocalizationNode::odom_callback(const nav_msgs::msg::Odometry::SharedPtr msg)
+void ParticleFilterLocalizationNode::odom_callback(const nav_msgs::msg::Odometry::SharedPtr msg)
 {
     if (!map_received_) return;  // wait for map before moving particles
 
@@ -137,7 +137,7 @@ void LocalizationNode::odom_callback(const nav_msgs::msg::Odometry::SharedPtr ms
     publish_map_to_odom_tf();
 }
 
-void LocalizationNode::scan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
+void ParticleFilterLocalizationNode::scan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
 {
     if (!map_received_) return;
 
@@ -151,7 +151,7 @@ void LocalizationNode::scan_callback(const sensor_msgs::msg::LaserScan::SharedPt
     publish_map_to_odom_tf();
 }
 
-void LocalizationNode::publish_particles()
+void ParticleFilterLocalizationNode::publish_particles()
 {
     geometry_msgs::msg::PoseArray msg;
     msg.header.stamp    = this->now();
@@ -170,7 +170,7 @@ void LocalizationNode::publish_particles()
     particle_pub_->publish(msg);
 }
 
-void LocalizationNode::publish_estimated_pose()
+void ParticleFilterLocalizationNode::publish_estimated_pose()
 {
     EstimatedPose estimate = pf_.estimatePose();
 
@@ -185,7 +185,7 @@ void LocalizationNode::publish_estimated_pose()
     estimated_pose_pub_->publish(msg);
 }
 
-void LocalizationNode::publish_map_to_odom_tf()
+void ParticleFilterLocalizationNode::publish_map_to_odom_tf()
 {
     EstimatedPose estimate = pf_.estimatePose();
 
@@ -229,7 +229,7 @@ void LocalizationNode::publish_map_to_odom_tf()
 int main(int argc, char ** argv)
 {
     rclcpp::init(argc, argv);
-    auto node = std::make_shared<LocalizationNode>();
+    auto node = std::make_shared<ParticleFilterLocalizationNode>();
     rclcpp::spin(node);
     rclcpp::shutdown();
     return 0;


### PR DESCRIPTION
## Summary

- Add a prediction-only Kalman localization algorithm with `[x, y, theta]` state and covariance tracking.
- Add a separate `kalman_localization_node` that subscribes to `/odom`, publishes `/estimated_pose`, `/estimated_pose_with_covariance`, and broadcasts `map -> odom`.
- Rename the existing particle-filter ROS node executable/source to `particle_filter_localization_node` for clearer algorithm ownership.
- Update root and localization README docs with the two localization node options.

## Notes

The Kalman v1 assumes the robot starts from known pose `0, 0, 0`. It does not use `/map` or `/scan` yet, so it is a local odometry-based pose tracker with covariance output, not global localization.

## Validation

```bash
colcon build --packages-select localization
```