### PR TITLE
Add scan matching correction to Kalman localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ The particle filter:
 - publishes the estimated pose and the normal ROS `map -> odom` transform
 
 The Kalman-filter node assumes a known initial pose of `0, 0, 0`.
-It reads `/odom` and publishes `/estimated_pose`, `/estimated_pose_with_covariance`, and `map -> odom`.
+It reads `/map`, `/odom`, and `/scan`.
+It publishes `/estimated_pose`, `/estimated_pose_with_covariance`, `/scan_matched_pose`, and `map -> odom`.
+The scan-matched pose is debug output for checking local scan matching before it is used for Kalman correction.
 
 ## Quick Start
 
@@ -215,6 +217,8 @@ To run the Kalman-filter node instead:
 ros2 run localization kalman_localization_node
 ```
 
+For the Kalman-filter node, add `/estimated_pose`, `/estimated_pose_with_covariance`, and `/scan_matched_pose` in RViz.
+
 Do not run both localization nodes at the same time.
 
 ## Project Structure
@@ -233,4 +237,4 @@ gazebo_ws/
 - Simulation works.
 - Mapping works as a basic occupancy grid mapper.
 - Localization includes a particle-filter node with likelihood-field scan scoring.
-- Localization includes a simple prediction-only Kalman-filter node with covariance output.
+- Localization includes a simple prediction-only Kalman-filter node with covariance and scan-matching debug output.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ The particle filter:
 The Kalman-filter node assumes a known initial pose of `0, 0, 0`.
 It reads `/map`, `/odom`, and `/scan`.
 It publishes `/estimated_pose`, `/estimated_pose_with_covariance`, `/scan_matched_pose`, and `map -> odom`.
-The scan-matched pose is debug output for checking local scan matching before it is used for Kalman correction.
+The scan-matched pose is also used as a Kalman correction measurement when its score and distance gates pass.
+It is a local tracker, so large odometry errors can still make it lose the actual pose.
 
 ## Quick Start
 
@@ -237,4 +238,4 @@ gazebo_ws/
 - Simulation works.
 - Mapping works as a basic occupancy grid mapper.
 - Localization includes a particle-filter node with likelihood-field scan scoring.
-- Localization includes a simple prediction-only Kalman-filter node with covariance and scan-matching debug output.
+- Localization includes a simple Kalman-filter node with odometry prediction, scan-matching correction, and covariance output.

--- a/src/localization/CMakeLists.txt
+++ b/src/localization/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(particle_filter_localization_node
 add_executable(kalman_localization_node
   src/kalman_localization_node.cpp
   src/kalman_filter.cpp
+  src/scan_matcher.cpp
 )
 
 # 1. tell cmake where to find header files
@@ -60,6 +61,7 @@ ament_target_dependencies(particle_filter_localization_node
 
 ament_target_dependencies(kalman_localization_node
   rclcpp
+  sensor_msgs
   nav_msgs
   geometry_msgs
   tf2

--- a/src/localization/README.md
+++ b/src/localization/README.md
@@ -9,7 +9,7 @@ The goal is to estimate where the robot is on a known map.
 The package has two learning localization nodes:
 
 - `particle_filter_localization_node`: a first particle-filter localizer using `/map`, `/odom`, and `/scan`
-- `kalman_localization_node`: a first Kalman-filter pose tracker using `/odom`
+- `kalman_localization_node`: a first Kalman-filter pose tracker using `/odom`, with scan-matching debug output
 
 Do not run both nodes at the same time.
 Both publish `/estimated_pose` and the `map -> odom` transform.
@@ -82,12 +82,15 @@ theta = 0
 
 It subscribes to:
 
+- `/map`
 - `/odom`
+- `/scan`
 
 It publishes:
 
 - `/estimated_pose`
 - `/estimated_pose_with_covariance`
+- `/scan_matched_pose`
 - TF: `map -> odom`
 
 This version is prediction-only.
@@ -97,8 +100,13 @@ It also grows a covariance matrix to show increasing uncertainty as the robot mo
 The covariance grows only when odometry changes more than a small threshold.
 This keeps the covariance from growing while the robot is standing still.
 
-This node does not use `/map` or `/scan` yet.
-It is not global localization.
+The node also runs a first local scan matcher.
+The scan matcher searches around the current Kalman estimate, scores candidate poses against a likelihood field built from `/map`, and publishes the best local match on `/scan_matched_pose`.
+
+This scan-matched pose is not used to correct the Kalman filter yet.
+It is debug output for checking whether scan matching works before adding Kalman correction.
+
+This node is not global localization.
 It is a local pose tracker from a known starting pose.
 
 ## Build
@@ -175,6 +183,7 @@ In RViz, add:
 
 - `/estimated_pose`
 - `/estimated_pose_with_covariance`
+- `/scan_matched_pose`
 
 Do not run the particle-filter node and Kalman-filter node together.
 

--- a/src/localization/README.md
+++ b/src/localization/README.md
@@ -93,8 +93,8 @@ It publishes:
 - `/scan_matched_pose`
 - TF: `map -> odom`
 
-This version is prediction-only.
-It uses odometry deltas to update `[x, y, theta]`.
+This version uses odometry prediction and scan-matching correction.
+Odometry deltas predict `[x, y, theta]`.
 It also grows a covariance matrix to show increasing uncertainty as the robot moves.
 
 The covariance grows only when odometry changes more than a small threshold.
@@ -103,11 +103,13 @@ This keeps the covariance from growing while the robot is standing still.
 The node also runs a first local scan matcher.
 The scan matcher searches around the current Kalman estimate, scores candidate poses against a likelihood field built from `/map`, and publishes the best local match on `/scan_matched_pose`.
 
-This scan-matched pose is not used to correct the Kalman filter yet.
-It is debug output for checking whether scan matching works before adding Kalman correction.
+When the scan-match score is good enough and the matched pose is close enough to the current prediction, the node uses that pose as a Kalman correction measurement.
+This pulls the estimate toward the scan-matched pose and reduces covariance.
 
 This node is not global localization.
 It is a local pose tracker from a known starting pose.
+If odometry becomes very wrong, such as when the robot drives against a wall while odometry still reports motion, the estimate may move outside the scan matcher's local search window.
+In that case, this version may not recover without a future recovery or relocalization strategy.
 
 ## Build
 

--- a/src/localization/include/localization/kalman_filter.hpp
+++ b/src/localization/include/localization/kalman_filter.hpp
@@ -37,6 +37,10 @@ public:
         double old_x, double old_y, double old_theta,
         double new_x, double new_y, double new_theta);
 
+    void correctWithPoseMeasurement(
+        double measured_x, double measured_y, double measured_theta,
+        const Matrix3x3 & measurement_covariance);
+
     bool isInitialized() const;
 
     KalmanPose estimatePose() const;

--- a/src/localization/include/localization/scan_matcher.hpp
+++ b/src/localization/include/localization/scan_matcher.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+
+struct ScanMatcherParameters {
+    double search_xy_range = 0.20;
+    double search_theta_range = 0.20;
+    double search_xy_step = 0.05;
+    double search_theta_step = 0.05;
+    std::size_t beam_step = 10;
+    double likelihood_max_distance = 1.0;
+};
+
+struct ScanMatchPose {
+    double x;
+    double y;
+    double theta;
+};
+
+struct ScanMatchResult {
+    ScanMatchPose pose;
+    double score;
+    bool valid;
+};
+
+class ScanMatcher
+{
+public:
+    explicit ScanMatcher(const ScanMatcherParameters & parameters = ScanMatcherParameters());
+
+    void setMap(const nav_msgs::msg::OccupancyGrid & map);
+
+    bool hasMap() const;
+
+    ScanMatchResult match(
+        const sensor_msgs::msg::LaserScan & scan,
+        const ScanMatchPose & initial_guess) const;
+
+    const nav_msgs::msg::OccupancyGrid & likelihoodFieldMap() const;
+
+private:
+    void buildLikelihoodField(const nav_msgs::msg::OccupancyGrid & map);
+    double scoreScanAtPose(
+        const sensor_msgs::msg::LaserScan & scan,
+        const ScanMatchPose & pose) const;
+    bool worldToLikelihoodMap(double x, double y, int & col, int & row) const;
+    double likelihoodAtWorld(double x, double y) const;
+    double normalizeAngle(double angle) const;
+
+    ScanMatcherParameters parameters_;
+    nav_msgs::msg::OccupancyGrid likelihood_field_map_;
+};

--- a/src/localization/src/kalman_filter.cpp
+++ b/src/localization/src/kalman_filter.cpp
@@ -49,6 +49,46 @@ void KalmanFilter::predictFromOdometry(
     }
 }
 
+void KalmanFilter::correctWithPoseMeasurement(
+    double measured_x, double measured_y, double measured_theta,
+    const Matrix3x3 & measurement_covariance)
+{
+    if (!initialized_) {
+        return;
+    }
+
+    double innovation_x = measured_x - state_.x;
+    double innovation_y = measured_y - state_.y;
+    double innovation_theta = normalizeAngle(measured_theta - state_.theta);
+
+    double innovation[3] = {innovation_x, innovation_y, innovation_theta};
+    int diagonal_indices[3] = {0, 4, 8};
+
+    for (int i = 0; i < 3; ++i) {
+        int index = diagonal_indices[i];
+        double predicted_variance = covariance_[index];
+        double measurement_variance = measurement_covariance[index];
+        double innovation_variance = predicted_variance + measurement_variance;
+
+        if (innovation_variance <= 0.0) {
+            continue;
+        }
+
+        double kalman_gain = predicted_variance / innovation_variance;
+        double correction = kalman_gain * innovation[i];
+
+        if (i == 0) {
+            state_.x += correction;
+        } else if (i == 1) {
+            state_.y += correction;
+        } else {
+            state_.theta = normalizeAngle(state_.theta + correction);
+        }
+
+        covariance_[index] = (1.0 - kalman_gain) * predicted_variance;
+    }
+}
+
 bool KalmanFilter::isInitialized() const
 {
     return initialized_;

--- a/src/localization/src/kalman_localization_node.cpp
+++ b/src/localization/src/kalman_localization_node.cpp
@@ -33,6 +33,12 @@ private:
     void publish_map_to_odom_tf(
         double odom_x, double odom_y, double odom_theta,
         const rclcpp::Time & stamp);
+    bool should_use_scan_match_correction(
+        const ScanMatchResult & match,
+        const KalmanPose & prediction) const;
+    KalmanFilter::Matrix3x3 scan_match_measurement_covariance() const;
+    double normalize_angle(double angle) const;
+    double square(double value) const;
     geometry_msgs::msg::Quaternion yaw_to_quaternion(double yaw) const;
 
     rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr map_sub_;
@@ -51,6 +57,13 @@ private:
     double last_odom_y_ = 0.0;
     double last_odom_theta_ = 0.0;
     bool odom_initialized_ = false;
+
+    double min_scan_match_score_ = 0.40;
+    double max_correction_translation_ = 0.25;
+    double max_correction_rotation_ = 0.25;
+    double scan_match_std_x_ = 0.08;
+    double scan_match_std_y_ = 0.08;
+    double scan_match_std_theta_ = 0.08;
 };
 
 KalmanLocalizationNode::KalmanLocalizationNode()
@@ -145,6 +158,22 @@ void KalmanLocalizationNode::scan_callback(const sensor_msgs::msg::LaserScan::Sh
     }
 
     publish_scan_matched_pose(match);
+
+    if (should_use_scan_match_correction(match, estimate)) {
+        kf_.correctWithPoseMeasurement(
+            match.pose.x,
+            match.pose.y,
+            match.pose.theta,
+            scan_match_measurement_covariance());
+
+        publish_estimated_pose();
+        publish_estimated_pose_with_covariance();
+
+        if (odom_initialized_) {
+            publish_map_to_odom_tf(
+                last_odom_x_, last_odom_y_, last_odom_theta_, msg->header.stamp);
+        }
+    }
 }
 
 void KalmanLocalizationNode::publish_estimated_pose()
@@ -227,6 +256,48 @@ void KalmanLocalizationNode::publish_map_to_odom_tf(
     msg.transform = tf2::toMsg(map_to_odom);
 
     tf_broadcaster_->sendTransform(msg);
+}
+
+bool KalmanLocalizationNode::should_use_scan_match_correction(
+    const ScanMatchResult & match,
+    const KalmanPose & prediction) const
+{
+    if (match.score < min_scan_match_score_) {
+        return false;
+    }
+
+    double dx = match.pose.x - prediction.x;
+    double dy = match.pose.y - prediction.y;
+    double translation_error = std::sqrt(dx * dx + dy * dy);
+    double rotation_error = std::abs(normalize_angle(match.pose.theta - prediction.theta));
+
+    return translation_error <= max_correction_translation_ &&
+        rotation_error <= max_correction_rotation_;
+}
+
+KalmanFilter::Matrix3x3 KalmanLocalizationNode::scan_match_measurement_covariance() const
+{
+    return {
+        square(scan_match_std_x_), 0.0, 0.0,
+        0.0, square(scan_match_std_y_), 0.0,
+        0.0, 0.0, square(scan_match_std_theta_)
+    };
+}
+
+double KalmanLocalizationNode::normalize_angle(double angle) const
+{
+    while (angle > M_PI) {
+        angle -= 2.0 * M_PI;
+    }
+    while (angle < -M_PI) {
+        angle += 2.0 * M_PI;
+    }
+    return angle;
+}
+
+double KalmanLocalizationNode::square(double value) const
+{
+    return value * value;
 }
 
 geometry_msgs::msg::Quaternion KalmanLocalizationNode::yaw_to_quaternion(double yaw) const

--- a/src/localization/src/kalman_localization_node.cpp
+++ b/src/localization/src/kalman_localization_node.cpp
@@ -1,5 +1,7 @@
 #include "rclcpp/rclcpp.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
@@ -13,6 +15,7 @@
 #include <tf2_ros/transform_broadcaster.h>
 
 #include "localization/kalman_filter.hpp"
+#include "localization/scan_matcher.hpp"
 
 class KalmanLocalizationNode : public rclcpp::Node
 {
@@ -20,22 +23,29 @@ public:
     KalmanLocalizationNode();
 
 private:
+    void map_callback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg);
     void odom_callback(const nav_msgs::msg::Odometry::SharedPtr msg);
+    void scan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
 
     void publish_estimated_pose();
     void publish_estimated_pose_with_covariance();
+    void publish_scan_matched_pose(const ScanMatchResult & match);
     void publish_map_to_odom_tf(
         double odom_x, double odom_y, double odom_theta,
         const rclcpp::Time & stamp);
     geometry_msgs::msg::Quaternion yaw_to_quaternion(double yaw) const;
 
+    rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr map_sub_;
     rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+    rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr estimated_pose_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr scan_matched_pose_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
         estimated_pose_with_covariance_pub_;
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
     KalmanFilter kf_;
+    ScanMatcher scan_matcher_;
 
     double last_odom_x_ = 0.0;
     double last_odom_y_ = 0.0;
@@ -49,12 +59,26 @@ KalmanLocalizationNode::KalmanLocalizationNode()
     kf_.initialize(0.0, 0.0, 0.0);
     tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
 
+    rclcpp::QoS static_map_qos(1);
+    static_map_qos.transient_local();
+    static_map_qos.reliable();
+
+    map_sub_ = this->create_subscription<nav_msgs::msg::OccupancyGrid>(
+        "/map", static_map_qos,
+        std::bind(&KalmanLocalizationNode::map_callback, this, std::placeholders::_1));
+
     odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
         "/odom", 10,
         std::bind(&KalmanLocalizationNode::odom_callback, this, std::placeholders::_1));
 
+    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>(
+        "/scan", 10,
+        std::bind(&KalmanLocalizationNode::scan_callback, this, std::placeholders::_1));
+
     estimated_pose_pub_ =
         this->create_publisher<geometry_msgs::msg::PoseStamped>("/estimated_pose", 10);
+    scan_matched_pose_pub_ =
+        this->create_publisher<geometry_msgs::msg::PoseStamped>("/scan_matched_pose", 10);
     estimated_pose_with_covariance_pub_ =
         this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
             "/estimated_pose_with_covariance", 10);
@@ -62,6 +86,16 @@ KalmanLocalizationNode::KalmanLocalizationNode()
     RCLCPP_INFO(
         this->get_logger(),
         "KalmanLocalizationNode started with initial pose x=0.0 y=0.0 theta=0.0.");
+}
+
+void KalmanLocalizationNode::map_callback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg)
+{
+    scan_matcher_.setMap(*msg);
+    RCLCPP_INFO(
+        this->get_logger(),
+        "Map received: %d x %d cells. Scan matcher likelihood field built.",
+        msg->info.width,
+        msg->info.height);
 }
 
 void KalmanLocalizationNode::odom_callback(const nav_msgs::msg::Odometry::SharedPtr msg)
@@ -91,6 +125,26 @@ void KalmanLocalizationNode::odom_callback(const nav_msgs::msg::Odometry::Shared
     publish_estimated_pose();
     publish_estimated_pose_with_covariance();
     publish_map_to_odom_tf(x, y, theta, msg->header.stamp);
+}
+
+void KalmanLocalizationNode::scan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
+{
+    if (!scan_matcher_.hasMap()) {
+        return;
+    }
+
+    KalmanPose estimate = kf_.estimatePose();
+    ScanMatchPose initial_guess;
+    initial_guess.x = estimate.x;
+    initial_guess.y = estimate.y;
+    initial_guess.theta = estimate.theta;
+
+    ScanMatchResult match = scan_matcher_.match(*msg, initial_guess);
+    if (!match.valid) {
+        return;
+    }
+
+    publish_scan_matched_pose(match);
 }
 
 void KalmanLocalizationNode::publish_estimated_pose()
@@ -130,6 +184,18 @@ void KalmanLocalizationNode::publish_estimated_pose_with_covariance()
     msg.pose.covariance[35] = covariance[8];
 
     estimated_pose_with_covariance_pub_->publish(msg);
+}
+
+void KalmanLocalizationNode::publish_scan_matched_pose(const ScanMatchResult & match)
+{
+    geometry_msgs::msg::PoseStamped msg;
+    msg.header.stamp = this->now();
+    msg.header.frame_id = "map";
+    msg.pose.position.x = match.pose.x;
+    msg.pose.position.y = match.pose.y;
+    msg.pose.orientation = yaw_to_quaternion(match.pose.theta);
+
+    scan_matched_pose_pub_->publish(msg);
 }
 
 void KalmanLocalizationNode::publish_map_to_odom_tf(

--- a/src/localization/src/scan_matcher.cpp
+++ b/src/localization/src/scan_matcher.cpp
@@ -1,0 +1,220 @@
+#include "localization/scan_matcher.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <queue>
+#include <vector>
+
+ScanMatcher::ScanMatcher(const ScanMatcherParameters & parameters)
+: parameters_(parameters)
+{
+}
+
+void ScanMatcher::setMap(const nav_msgs::msg::OccupancyGrid & map)
+{
+    buildLikelihoodField(map);
+}
+
+bool ScanMatcher::hasMap() const
+{
+    return !likelihood_field_map_.data.empty();
+}
+
+ScanMatchResult ScanMatcher::match(
+    const sensor_msgs::msg::LaserScan & scan,
+    const ScanMatchPose & initial_guess) const
+{
+    ScanMatchResult result;
+    result.pose = initial_guess;
+    result.score = 0.0;
+    result.valid = false;
+
+    if (!hasMap() || scan.ranges.empty()) {
+        return result;
+    }
+
+    double best_score = -std::numeric_limits<double>::infinity();
+    ScanMatchPose best_pose = initial_guess;
+
+    for (double dx = -parameters_.search_xy_range;
+        dx <= parameters_.search_xy_range + 1e-9;
+        dx += parameters_.search_xy_step)
+    {
+        for (double dy = -parameters_.search_xy_range;
+            dy <= parameters_.search_xy_range + 1e-9;
+            dy += parameters_.search_xy_step)
+        {
+            for (double dtheta = -parameters_.search_theta_range;
+                dtheta <= parameters_.search_theta_range + 1e-9;
+                dtheta += parameters_.search_theta_step)
+            {
+                ScanMatchPose candidate;
+                candidate.x = initial_guess.x + dx;
+                candidate.y = initial_guess.y + dy;
+                candidate.theta = normalizeAngle(initial_guess.theta + dtheta);
+
+                double score = scoreScanAtPose(scan, candidate);
+                if (score > best_score) {
+                    best_score = score;
+                    best_pose = candidate;
+                }
+            }
+        }
+    }
+
+    if (std::isfinite(best_score)) {
+        result.pose = best_pose;
+        result.score = best_score;
+        result.valid = true;
+    }
+
+    return result;
+}
+
+const nav_msgs::msg::OccupancyGrid & ScanMatcher::likelihoodFieldMap() const
+{
+    return likelihood_field_map_;
+}
+
+void ScanMatcher::buildLikelihoodField(const nav_msgs::msg::OccupancyGrid & map)
+{
+    likelihood_field_map_ = map;
+
+    int width = map.info.width;
+    int height = map.info.height;
+    int total_cells = width * height;
+    double resolution = map.info.resolution;
+
+    int max_distance_cells =
+        static_cast<int>(std::ceil(parameters_.likelihood_max_distance / resolution));
+
+    std::vector<int> distance_to_wall(total_cells, max_distance_cells);
+    std::queue<int> cells_to_visit;
+
+    for (int i = 0; i < total_cells; ++i) {
+        if (map.data[i] > 50) {
+            distance_to_wall[i] = 0;
+            cells_to_visit.push(i);
+        }
+    }
+
+    const int neighbor_offsets[4][2] = {
+        {1, 0},
+        {-1, 0},
+        {0, 1},
+        {0, -1}
+    };
+
+    while (!cells_to_visit.empty()) {
+        int index = cells_to_visit.front();
+        cells_to_visit.pop();
+
+        int row = index / width;
+        int col = index % width;
+        int next_distance = distance_to_wall[index] + 1;
+
+        if (next_distance > max_distance_cells) {
+            continue;
+        }
+
+        for (const auto & offset : neighbor_offsets) {
+            int next_col = col + offset[0];
+            int next_row = row + offset[1];
+
+            if (next_col < 0 || next_row < 0 || next_col >= width || next_row >= height) {
+                continue;
+            }
+
+            int next_index = next_row * width + next_col;
+            if (next_distance >= distance_to_wall[next_index]) {
+                continue;
+            }
+
+            distance_to_wall[next_index] = next_distance;
+            cells_to_visit.push(next_index);
+        }
+    }
+
+    likelihood_field_map_.data.assign(total_cells, 0);
+
+    for (int i = 0; i < total_cells; ++i) {
+        double distance_m = distance_to_wall[i] * resolution;
+        double likelihood =
+            1.0 - std::min(distance_m / parameters_.likelihood_max_distance, 1.0);
+
+        likelihood_field_map_.data[i] =
+            static_cast<int8_t>(std::round(likelihood * 100.0));
+    }
+}
+
+double ScanMatcher::scoreScanAtPose(
+    const sensor_msgs::msg::LaserScan & scan,
+    const ScanMatchPose & pose) const
+{
+    double score = 0.0;
+    int used_beams = 0;
+
+    for (std::size_t i = 0; i < scan.ranges.size(); i += parameters_.beam_step) {
+        float range = scan.ranges[i];
+
+        if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
+            continue;
+        }
+
+        double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
+        double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
+        double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
+
+        score += likelihoodAtWorld(hit_x, hit_y);
+        used_beams++;
+    }
+
+    if (used_beams == 0) {
+        return 0.0;
+    }
+
+    return score / used_beams;
+}
+
+bool ScanMatcher::worldToLikelihoodMap(double x, double y, int & col, int & row) const
+{
+    if (!hasMap()) {
+        return false;
+    }
+
+    double resolution = likelihood_field_map_.info.resolution;
+    double origin_x = likelihood_field_map_.info.origin.position.x;
+    double origin_y = likelihood_field_map_.info.origin.position.y;
+
+    col = static_cast<int>(std::floor((x - origin_x) / resolution));
+    row = static_cast<int>(std::floor((y - origin_y) / resolution));
+
+    return col >= 0 &&
+        row >= 0 &&
+        col < static_cast<int>(likelihood_field_map_.info.width) &&
+        row < static_cast<int>(likelihood_field_map_.info.height);
+}
+
+double ScanMatcher::likelihoodAtWorld(double x, double y) const
+{
+    int col = 0;
+    int row = 0;
+    if (!worldToLikelihoodMap(x, y, col, row)) {
+        return 0.0;
+    }
+
+    int index = row * likelihood_field_map_.info.width + col;
+    return likelihood_field_map_.data[index] / 100.0;
+}
+
+double ScanMatcher::normalizeAngle(double angle) const
+{
+    while (angle > M_PI) {
+        angle -= 2.0 * M_PI;
+    }
+    while (angle < -M_PI) {
+        angle += 2.0 * M_PI;
+    }
+    return angle;
+}


### PR DESCRIPTION
## Summary

- Add local scan matching around the Kalman estimate using a likelihood field built from `/map`.
- Publish `/scan_matched_pose` for RViz/debugging.
- Use accepted scan matches as Kalman correction measurements when score and distance gates pass.
- Document the current limitation that large odometry errors can move the estimate outside the local scan-matching window.

## Notes

The Kalman node is still a local tracker from a known initial pose, not global localization. A wall collision or wheel slip can still create enough odometry error that future recovery logic is needed.

Related issue: https://github.com/JinTTTT/simple_mobile_robot/issues/17

## Validation

```bash
colcon build --packages-select localization
```