### PR TITLE
Add first SLAM package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The long term goal is to learn:
 - simulation: finished
 - mapping: finished
 - localization : finished
-- SLAM : in progress
+- SLAM : first version finished
 - planning : in planning
 - navigation : in planning
 
@@ -87,6 +87,39 @@ It reads `/map`, `/odom`, and `/scan`.
 It publishes `/estimated_pose`, `/estimated_pose_with_covariance`, `/scan_matched_pose`, and `map -> odom`.
 The scan-matched pose is also used as a Kalman correction measurement when its score and distance gates pass.
 It is a local tracker, so large odometry errors can still make it lose the actual pose.
+
+### `slam`
+
+This package is the first learning version of SLAM.
+
+It reads:
+
+- `/odom`
+- `/scan`
+
+It publishes:
+
+- `/map`
+- `/corrected_map`
+- `/estimated_pose`
+- `/scan_matched_pose`
+- `/trajectory`
+- `/corrected_trajectory`
+- `/loop_closure_pose`
+- TF: `map -> odom`
+
+Simple logic:
+
+- predict pose from odometry
+- use local scan matching for small pose correction
+- build a live occupancy-grid map
+- store trajectory history and keyframes
+- detect loop closure from old keyframes
+- apply a simple evenly spread trajectory correction
+- rebuild a corrected map from corrected keyframes
+
+This SLAM package is good enough as a first learning version.
+It does not yet do full pose graph optimization or robust wall-hit recovery.
 
 ## Quick Start
 
@@ -226,12 +259,57 @@ For the Kalman-filter node, add `/estimated_pose`, `/estimated_pose_with_covaria
 
 Do not run both localization nodes at the same time.
 
+## Run Case 3: SLAM
+
+### 1. Start simulation
+
+```bash
+ros2 launch simulation bringup_simulation.launch.py
+```
+
+### 2. Start teleop
+
+```bash
+ros2 run teleop_twist_keyboard teleop_twist_keyboard
+```
+
+### 3. Start SLAM
+
+```bash
+ros2 launch slam simple_slam.launch.py
+```
+
+### 4. Start RViz
+
+```bash
+rviz2
+```
+
+In RViz:
+
+- set Fixed Frame to `map`
+- add `/map`
+- add `/corrected_map`
+- add `/estimated_pose`
+- add `/trajectory`
+- add `/corrected_trajectory`
+- add `/loop_closure_pose`
+- add `TF`
+
+During normal driving:
+
+- `/map` is the live online map
+- `/corrected_map` is rebuilt from corrected keyframes after loop-closure correction
+- `/trajectory` is the raw path
+- `/corrected_trajectory` is the loop-corrected keyframe path
+
 ## Project Structure
 
 ```text
 gazebo_ws/
 ├── README.md
 └── src/
+    ├── slam/
     ├── simulation/
     ├── mapping/
     └── localization/
@@ -243,3 +321,5 @@ gazebo_ws/
 - Mapping works as a basic occupancy grid mapper.
 - Localization includes a particle-filter node with likelihood-field scan scoring.
 - Localization includes a simple Kalman-filter node with odometry prediction, scan-matching correction, and covariance output.
+- SLAM v1 includes live mapping, local scan matching, trajectory history, loop-closure detection, simple trajectory correction, and corrected-map rebuilding.
+- SLAM v1 still has known limitations in wall-hit / odometry-disagreement cases and does not yet include pose graph optimization.

--- a/src/slam/CMakeLists.txt
+++ b/src/slam/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.8)
+project(slam)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+add_executable(simple_slam_node
+  src/simple_slam_node.cpp
+)
+
+ament_target_dependencies(simple_slam_node
+  rclcpp
+  sensor_msgs
+  nav_msgs
+  geometry_msgs
+  tf2
+  tf2_ros
+  tf2_geometry_msgs
+)
+
+install(TARGETS
+  simple_slam_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/slam/README.md
+++ b/src/slam/README.md
@@ -28,12 +28,13 @@ or:
 ros2 launch slam simple_slam.launch.py
 ```
 
-This currently includes Stage 1 through Stage 4:
+This currently includes Stage 1 through Stage 5:
 
 - Stage 1: build a live occupancy grid map from lidar scans
 - Stage 2: use local scan matching to slightly correct the odometry pose before updating the map
 - Stage 3: store and publish the estimated trajectory
 - Stage 4: detect simple loop closures
+- Stage 5: apply a simple equally spread trajectory correction between loop-closure keyframes
 
 The current algorithm is:
 
@@ -48,7 +49,8 @@ The current algorithm is:
 9. Add the estimated pose to the trajectory.
 10. Save occasional keyframes.
 11. Compare the current scan with old nearby keyframes to detect loop closure.
-12. Publish the map, estimated pose, scan-matched pose, trajectory, loop-closure pose, and `map -> odom`.
+12. If a loop closure is detected, spread the closing error from the old keyframe to the current keyframe.
+13. Publish the map, estimated pose, scan-matched pose, raw trajectory, corrected trajectory, loop-closure pose, and `map -> odom`.
 
 In short:
 
@@ -73,6 +75,7 @@ The node publishes:
 - `/estimated_pose`: the final SLAM pose estimate in the `map` frame
 - `/scan_matched_pose`: the pose found by scan matching when scan matching is accepted
 - `/trajectory`: the history of estimated robot poses as a `nav_msgs/Path`
+- `/corrected_trajectory`: keyframe path after simple loop-closure correction
 - `/loop_closure_pose`: the old keyframe pose matched when a loop closure is detected
 - TF: `map -> odom`
 
@@ -142,8 +145,40 @@ This package also adds new learning methods:
 - keyframes: saved poses plus a small summary of the laser scan
 - trajectory history: all estimated poses published as a path
 - loop-closure detection: checking whether the robot has returned near an older keyframe with a similar scan
+- simple loop-closure correction: spreading the error evenly between the old matched keyframe and the current keyframe
 
-The loop-closure stage is detection only. It does not correct the map yet.
+The correction is intentionally simple. It corrects the published keyframe trajectory, not the live robot pose and not the map.
+
+## Simple Loop-Closure Correction
+
+When loop closure says:
+
+```text
+current keyframe should line up with old keyframe
+```
+
+the node computes the difference:
+
+```text
+error = old corrected pose - current corrected pose
+```
+
+Then it spreads that error across the keyframes from the old keyframe to the current keyframe.
+
+Example:
+
+```text
+old keyframe = 4
+current keyframe = 20
+```
+
+The correction is applied like this:
+
+- keyframe 4 gets 0% correction
+- keyframe 12 gets about 50% correction
+- keyframe 20 gets 100% correction
+
+This bends the corrected keyframe path toward the old place. It is not a full graph optimizer, but it shows the main idea of using loop closure to repair drift.
 
 ## Terminal Output
 
@@ -172,24 +207,24 @@ This is still not full SLAM yet.
 
 Current limits:
 
-- no pose graph
-- no graph optimization
+- no real pose graph solver
+- no nonlinear graph optimization
 - no global relocalization
 - no map rebuilding after old pose corrections
-- loop closure is detection only and does not fix the map yet
+- loop closure corrects only `/corrected_trajectory`, not `/map`
 - tuning values are still hard-coded
 
-It can correct small odometry errors and detect some returns to old places, but it cannot fix large drift yet.
+It can correct small odometry errors, detect some returns to old places, and show a simple corrected trajectory. It cannot fix the map yet.
 
 ## Future Stages
 
-Stage 5: pose graph optimization.
+Stage 6: pose graph optimization.
 
 - treat old poses as nodes in a graph
 - add movement and loop-closure constraints
 - adjust old poses so the full path becomes more consistent
 
-Stage 6: rebuild or correct the map.
+Stage 7: rebuild or correct the map.
 
 - after old poses are corrected, rebuild the map using corrected poses
 - this is how SLAM can fix a bent map after loop closure
@@ -235,9 +270,11 @@ In RViz:
 - add `/estimated_pose`
 - add `/scan_matched_pose`
 - add `/trajectory`
+- add `/corrected_trajectory`
 - add `/loop_closure_pose`
 - add `TF`
 
 Drive slowly at first. The map should grow around the robot.
 To test loop closure, drive a simple loop and return near an older place.
 When the detector finds a match, the terminal should print `Loop closure detected`, and `/loop_closure_pose` should point to the older matched keyframe.
+Compare `/trajectory` and `/corrected_trajectory` in RViz. After loop closure, the corrected path should bend closer to the old matched place.

--- a/src/slam/README.md
+++ b/src/slam/README.md
@@ -14,6 +14,29 @@ Simple meaning:
 
 This package is for learning and understanding. It starts with a small, readable SLAM version instead of a full professional SLAM system.
 
+## Status
+
+This package is now good enough to treat as SLAM v1.
+
+What SLAM v1 already does:
+
+- build a live occupancy-grid map from `/scan` and `/odom`
+- use local scan matching for small pose correction
+- publish a normal ROS `map -> odom` transform
+- store a trajectory and keyframes
+- detect loop closure from keyframe scan similarity
+- apply a simple loop-closure trajectory correction
+- rebuild a corrected map from corrected keyframes
+
+Known limits for SLAM v1:
+
+- no real pose graph optimizer
+- no full global relocalization
+- no robust wall-hit / odometry-disagreement recovery yet
+- `/corrected_map` is keyframe-based and may be sparser than `/map`
+
+Those limits are acceptable for this first learning version and are better tracked as future issues than blockers for closing the package.
+
 ## Current Stage
 
 The current node is:

--- a/src/slam/README.md
+++ b/src/slam/README.md
@@ -28,13 +28,14 @@ or:
 ros2 launch slam simple_slam.launch.py
 ```
 
-This currently includes Stage 1 through Stage 5:
+This currently includes Stage 1 through Stage 6:
 
 - Stage 1: build a live occupancy grid map from lidar scans
 - Stage 2: use local scan matching to slightly correct the odometry pose before updating the map
 - Stage 3: store and publish the estimated trajectory
 - Stage 4: detect simple loop closures
 - Stage 5: apply a simple equally spread trajectory correction between loop-closure keyframes
+- Stage 6: rebuild a corrected map from stored keyframe scans and corrected keyframe poses
 
 The current algorithm is:
 
@@ -50,7 +51,8 @@ The current algorithm is:
 10. Save occasional keyframes.
 11. Compare the current scan with old nearby keyframes to detect loop closure.
 12. If a loop closure is detected, spread the closing error from the old keyframe to the current keyframe.
-13. Publish the map, estimated pose, scan-matched pose, raw trajectory, corrected trajectory, loop-closure pose, and `map -> odom`.
+13. If correction is applied, rebuild a corrected map from stored keyframe scans.
+14. Publish the live map, corrected map, estimated pose, scan-matched pose, raw trajectory, corrected trajectory, loop-closure pose, and `map -> odom`.
 
 In short:
 
@@ -72,6 +74,7 @@ The node subscribes to:
 The node publishes:
 
 - `/map`: the occupancy grid map being built live
+- `/corrected_map`: a map rebuilt from keyframe scans using corrected keyframe poses
 - `/estimated_pose`: the final SLAM pose estimate in the `map` frame
 - `/scan_matched_pose`: the pose found by scan matching when scan matching is accepted
 - `/trajectory`: the history of estimated robot poses as a `nav_msgs/Path`
@@ -143,11 +146,13 @@ update the map with the corrected pose
 This package also adds new learning methods:
 
 - keyframes: saved poses plus a small summary of the laser scan
+- stored keyframe scans: full lidar ranges saved so the map can be rebuilt later
 - trajectory history: all estimated poses published as a path
 - loop-closure detection: checking whether the robot has returned near an older keyframe with a similar scan
 - simple loop-closure correction: gently spreading part of the error between selected loop-closure keyframes
+- corrected map rebuilding: clearing a second map and reinserting stored keyframe scans at corrected poses
 
-The correction is intentionally simple. It corrects the published keyframe trajectory, not the live robot pose and not the map.
+The correction is intentionally simple. It corrects the published keyframe trajectory and rebuilds `/corrected_map`. It does not change the live robot pose.
 
 ## Simple Loop-Closure Correction
 
@@ -194,6 +199,24 @@ The correction is applied like this:
 
 This bends the corrected keyframe path toward the old place without yanking it too hard. It is not a full graph optimizer, but it shows the main idea of using loop closure to repair drift.
 
+## Corrected Map
+
+The live `/map` is updated online from every integrated scan using the current estimated pose. If the pose later gets corrected, old scan evidence already inserted into `/map` stays where it was.
+
+The corrected map works differently:
+
+1. Each keyframe stores the full lidar scan ranges.
+2. When a loop-closure correction is applied, the node clears `/corrected_map`.
+3. It reinserts every stored keyframe scan using that keyframe's `corrected_pose`.
+4. It publishes the result on `/corrected_map`.
+
+This means:
+
+- `/map` is the dense live map
+- `/corrected_map` is the rebuilt map from corrected keyframes
+
+The corrected map may be sparser than `/map` because it uses keyframe scans only.
+
 ## Terminal Output
 
 The node prints a small throttled summary while scans are integrated:
@@ -225,25 +248,25 @@ Current limits:
 - no real pose graph solver
 - no nonlinear graph optimization
 - no global relocalization
-- no map rebuilding after old pose corrections
 - loop closure correction is gated and partial, so some drift may remain
-- loop closure corrects only `/corrected_trajectory`, not `/map`
+- `/corrected_map` is rebuilt from keyframes only, so it may be less dense than `/map`
+- live `/estimated_pose` and live `/map` are not reset to the corrected trajectory
 - tuning values are still hard-coded
 
-It can correct small odometry errors, detect some returns to old places, and show a simple corrected trajectory. It cannot fix the map yet.
+It can correct small odometry errors, detect some returns to old places, show a simple corrected trajectory, and rebuild a keyframe-based corrected map.
 
 ## Future Stages
 
-Stage 6: pose graph optimization.
+Stage 7: pose graph optimization.
 
 - treat old poses as nodes in a graph
 - add movement and loop-closure constraints
 - adjust old poses so the full path becomes more consistent
 
-Stage 7: rebuild or correct the map.
+Stage 8: make the optimized map the main SLAM state.
 
-- after old poses are corrected, rebuild the map using corrected poses
-- this is how SLAM can fix a bent map after loop closure
+- feed optimized poses back into the live SLAM state
+- decide when `/corrected_map` should replace `/map`
 
 ## Run
 
@@ -283,6 +306,7 @@ In RViz:
 
 - set Fixed Frame to `map`
 - add `/map`
+- add `/corrected_map`
 - add `/estimated_pose`
 - add `/scan_matched_pose`
 - add `/trajectory`
@@ -294,3 +318,4 @@ Drive slowly at first. The map should grow around the robot.
 To test loop closure, drive a simple loop and return near an older place.
 When the detector finds a match, the terminal should print `Loop closure detected`, and `/loop_closure_pose` should point to the older matched keyframe.
 Compare `/trajectory` and `/corrected_trajectory` in RViz. After loop closure, the corrected path should bend closer to the old matched place.
+Compare `/map` and `/corrected_map`. After an applied correction, `/corrected_map` should rebuild from the corrected keyframe path.

--- a/src/slam/README.md
+++ b/src/slam/README.md
@@ -43,8 +43,8 @@ The current algorithm is:
 2. Apply that movement to the previous SLAM pose.
 3. If the robot has not moved enough, skip scan matching and map update.
 4. If the map is still too empty, trust the odometry prediction.
-5. If the map has enough walls, scan match around the odometry-predicted pose.
-6. If scan matching has a good enough score, use the scan-matched pose.
+5. If enough movement has happened since the last accepted scan match, scan match around the odometry-predicted pose.
+6. Accept scan matching only if it clearly improves the score over the odometry-predicted pose and the correction is not too large.
 7. Otherwise, use the odometry-predicted pose.
 8. Insert the lidar scan into the map using the chosen pose.
 9. Add the estimated pose to the trajectory.
@@ -116,6 +116,26 @@ else:
 ```
 
 This first version does not blend odometry and scan matching with a Kalman filter. It uses the simpler rule above because it is easier to inspect and understand.
+
+## Conservative Scan Matching
+
+The scan matcher is intentionally conservative because wrong scan-matching corrections can draw duplicate or angled walls into the live map.
+
+It now uses these ideas:
+
+- do not start scan matching too early; wait for enough occupied cells in the map
+- use a smaller heading search window
+- do not try scan matching too often
+- compare the best scan-match score against the score at the odometry-predicted pose
+- accept scan matching only if the score improvement is meaningful
+- reject scan matches that try to move the pose too far from odometry
+
+Simple meaning:
+
+```text
+odometry is the default
+scan matching is allowed only when it is clearly helpful
+```
 
 ## Reused Methods From Existing Packages
 
@@ -222,19 +242,21 @@ The corrected map may be sparser than `/map` because it uses keyframe scans only
 The node prints a small throttled summary while scans are integrated:
 
 ```text
-SLAM integrated=... stationary_skipped=... keyframes=... loops=... corrections=... pose=(x, y, theta) match=yes/no score=... occupied=...
+SLAM integrated=... stationary_skipped=... scan_match_used=... keyframes=... loops=... corrections=... pose=(x, y, theta) match=yes/no score=... predicted_score=... occupied=...
 ```
 
 Meaning:
 
 - `integrated`: scans inserted into the map
 - `stationary_skipped`: scans ignored because the robot did not move enough
+- `scan_match_used`: scans where scan matching was accepted
 - `keyframes`: saved keyframes for loop-closure checks
 - `loops`: detected loop closures
 - `corrections`: loop closures that actually changed `/corrected_trajectory`
 - `pose`: current estimated pose
 - `match`: whether scan matching corrected the pose
 - `score`: scan matching score
+- `predicted_score`: score of the odometry-predicted pose before correction
 - `occupied`: occupied cells in the current map
 
 When the robot is not moving, scan matching and map updates are skipped after the first scan. This keeps the node from repeatedly inserting the same scan and making the map over-confident.
@@ -251,6 +273,7 @@ Current limits:
 - loop closure correction is gated and partial, so some drift may remain
 - `/corrected_map` is rebuilt from keyframes only, so it may be less dense than `/map`
 - live `/estimated_pose` and live `/map` are not reset to the corrected trajectory
+- scan matching is still local and can fail in repeated geometry or large drift
 - tuning values are still hard-coded
 
 It can correct small odometry errors, detect some returns to old places, show a simple corrected trajectory, and rebuild a keyframe-based corrected map.

--- a/src/slam/README.md
+++ b/src/slam/README.md
@@ -145,7 +145,7 @@ This package also adds new learning methods:
 - keyframes: saved poses plus a small summary of the laser scan
 - trajectory history: all estimated poses published as a path
 - loop-closure detection: checking whether the robot has returned near an older keyframe with a similar scan
-- simple loop-closure correction: spreading the error evenly between the old matched keyframe and the current keyframe
+- simple loop-closure correction: gently spreading part of the error between selected loop-closure keyframes
 
 The correction is intentionally simple. It corrects the published keyframe trajectory, not the live robot pose and not the map.
 
@@ -163,7 +163,21 @@ the node computes the difference:
 error = old corrected pose - current corrected pose
 ```
 
-Then it spreads that error across the keyframes from the old keyframe to the current keyframe.
+The node does not correct every detected loop closure. After returning to a known area, many scans may match old places. Correcting every one of those matches can make the corrected path zigzag.
+
+So the node applies correction only when:
+
+- enough scans passed since the last correction
+- the old and current keyframes are far enough apart
+- the matched old keyframe is not too close to the previously corrected old keyframe
+
+When correction is accepted, the node applies only part of the error:
+
+```text
+used_error = 0.35 * full_error
+```
+
+Then it spreads that smaller error across the keyframes from the old keyframe to the current keyframe.
 
 Example:
 
@@ -176,16 +190,16 @@ The correction is applied like this:
 
 - keyframe 4 gets 0% correction
 - keyframe 12 gets about 50% correction
-- keyframe 20 gets 100% correction
+- keyframe 20 gets 100% of the selected correction
 
-This bends the corrected keyframe path toward the old place. It is not a full graph optimizer, but it shows the main idea of using loop closure to repair drift.
+This bends the corrected keyframe path toward the old place without yanking it too hard. It is not a full graph optimizer, but it shows the main idea of using loop closure to repair drift.
 
 ## Terminal Output
 
 The node prints a small throttled summary while scans are integrated:
 
 ```text
-SLAM integrated=... stationary_skipped=... keyframes=... loops=... pose=(x, y, theta) match=yes/no score=... occupied=...
+SLAM integrated=... stationary_skipped=... keyframes=... loops=... corrections=... pose=(x, y, theta) match=yes/no score=... occupied=...
 ```
 
 Meaning:
@@ -194,6 +208,7 @@ Meaning:
 - `stationary_skipped`: scans ignored because the robot did not move enough
 - `keyframes`: saved keyframes for loop-closure checks
 - `loops`: detected loop closures
+- `corrections`: loop closures that actually changed `/corrected_trajectory`
 - `pose`: current estimated pose
 - `match`: whether scan matching corrected the pose
 - `score`: scan matching score
@@ -211,6 +226,7 @@ Current limits:
 - no nonlinear graph optimization
 - no global relocalization
 - no map rebuilding after old pose corrections
+- loop closure correction is gated and partial, so some drift may remain
 - loop closure corrects only `/corrected_trajectory`, not `/map`
 - tuning values are still hard-coded
 

--- a/src/slam/README.md
+++ b/src/slam/README.md
@@ -28,10 +28,12 @@ or:
 ros2 launch slam simple_slam.launch.py
 ```
 
-This is Stage 1 and Stage 2:
+This currently includes Stage 1 through Stage 4:
 
 - Stage 1: build a live occupancy grid map from lidar scans
 - Stage 2: use local scan matching to slightly correct the odometry pose before updating the map
+- Stage 3: store and publish the estimated trajectory
+- Stage 4: detect simple loop closures
 
 The current algorithm is:
 
@@ -43,7 +45,10 @@ The current algorithm is:
 6. If scan matching has a good enough score, use the scan-matched pose.
 7. Otherwise, use the odometry-predicted pose.
 8. Insert the lidar scan into the map using the chosen pose.
-9. Publish the map, estimated pose, scan-matched pose, and `map -> odom`.
+9. Add the estimated pose to the trajectory.
+10. Save occasional keyframes.
+11. Compare the current scan with old nearby keyframes to detect loop closure.
+12. Publish the map, estimated pose, scan-matched pose, trajectory, loop-closure pose, and `map -> odom`.
 
 In short:
 
@@ -67,6 +72,8 @@ The node publishes:
 - `/map`: the occupancy grid map being built live
 - `/estimated_pose`: the final SLAM pose estimate in the `map` frame
 - `/scan_matched_pose`: the pose found by scan matching when scan matching is accepted
+- `/trajectory`: the history of estimated robot poses as a `nav_msgs/Path`
+- `/loop_closure_pose`: the old keyframe pose matched when a loop closure is detected
 - TF: `map -> odom`
 
 Gazebo already publishes:
@@ -130,18 +137,28 @@ correct pose with scan matching
 update the map with the corrected pose
 ```
 
+This package also adds new learning methods:
+
+- keyframes: saved poses plus a small summary of the laser scan
+- trajectory history: all estimated poses published as a path
+- loop-closure detection: checking whether the robot has returned near an older keyframe with a similar scan
+
+The loop-closure stage is detection only. It does not correct the map yet.
+
 ## Terminal Output
 
 The node prints a small throttled summary while scans are integrated:
 
 ```text
-SLAM integrated=... stationary_skipped=... pose=(x, y, theta) match=yes/no score=... occupied=...
+SLAM integrated=... stationary_skipped=... keyframes=... loops=... pose=(x, y, theta) match=yes/no score=... occupied=...
 ```
 
 Meaning:
 
 - `integrated`: scans inserted into the map
 - `stationary_skipped`: scans ignored because the robot did not move enough
+- `keyframes`: saved keyframes for loop-closure checks
+- `loops`: detected loop closures
 - `pose`: current estimated pose
 - `match`: whether scan matching corrected the pose
 - `score`: scan matching score
@@ -151,31 +168,20 @@ When the robot is not moving, scan matching and map updates are skipped after th
 
 ## Current Limits
 
-This is not full SLAM yet.
+This is still not full SLAM yet.
 
 Current limits:
 
-- no loop closure
 - no pose graph
 - no graph optimization
 - no global relocalization
 - no map rebuilding after old pose corrections
+- loop closure is detection only and does not fix the map yet
 - tuning values are still hard-coded
 
-It can correct small odometry errors, but it cannot fix large drift yet.
+It can correct small odometry errors and detect some returns to old places, but it cannot fix large drift yet.
 
 ## Future Stages
-
-Stage 3: store trajectory history.
-
-- save past robot poses
-- publish the robot path
-- make it easier to see drift over time
-
-Stage 4: detect loop closure.
-
-- notice when the robot returns to a place it has seen before
-- compare current scans with old map areas or old scans
 
 Stage 5: pose graph optimization.
 
@@ -228,6 +234,10 @@ In RViz:
 - add `/map`
 - add `/estimated_pose`
 - add `/scan_matched_pose`
+- add `/trajectory`
+- add `/loop_closure_pose`
 - add `TF`
 
 Drive slowly at first. The map should grow around the robot.
+To test loop closure, drive a simple loop and return near an older place.
+When the detector finds a match, the terminal should print `Loop closure detected`, and `/loop_closure_pose` should point to the older matched keyframe.

--- a/src/slam/README.md
+++ b/src/slam/README.md
@@ -1,0 +1,233 @@
+# SLAM Package
+
+SLAM means:
+
+```text
+Simultaneous Localization And Mapping
+```
+
+Simple meaning:
+
+- the robot does not start with a prebuilt map
+- the robot builds a map while it drives
+- the robot also estimates where it is inside that growing map
+
+This package is for learning and understanding. It starts with a small, readable SLAM version instead of a full professional SLAM system.
+
+## Current Stage
+
+The current node is:
+
+```bash
+ros2 run slam simple_slam_node
+```
+
+or:
+
+```bash
+ros2 launch slam simple_slam.launch.py
+```
+
+This is Stage 1 and Stage 2:
+
+- Stage 1: build a live occupancy grid map from lidar scans
+- Stage 2: use local scan matching to slightly correct the odometry pose before updating the map
+
+The current algorithm is:
+
+1. Read the robot movement from `/odom`.
+2. Apply that movement to the previous SLAM pose.
+3. If the robot has not moved enough, skip scan matching and map update.
+4. If the map is still too empty, trust the odometry prediction.
+5. If the map has enough walls, scan match around the odometry-predicted pose.
+6. If scan matching has a good enough score, use the scan-matched pose.
+7. Otherwise, use the odometry-predicted pose.
+8. Insert the lidar scan into the map using the chosen pose.
+9. Publish the map, estimated pose, scan-matched pose, and `map -> odom`.
+
+In short:
+
+```text
+odometry gives the first guess
+scan matching can correct the guess
+the chosen pose updates the map
+```
+
+## Inputs
+
+The node subscribes to:
+
+- `/odom`: odometry pose from the simulation
+- `/scan`: 2D lidar scans
+
+## Outputs
+
+The node publishes:
+
+- `/map`: the occupancy grid map being built live
+- `/estimated_pose`: the final SLAM pose estimate in the `map` frame
+- `/scan_matched_pose`: the pose found by scan matching when scan matching is accepted
+- TF: `map -> odom`
+
+Gazebo already publishes:
+
+```text
+odom -> base_link
+```
+
+The SLAM node publishes:
+
+```text
+map -> odom
+```
+
+Together, RViz can use:
+
+```text
+map -> odom -> base_link
+```
+
+## Pose Outputs
+
+`/odom` is the raw odometry estimate from the simulator.
+
+`/scan_matched_pose` is the pose where the current laser scan best fits the current map.
+
+`/estimated_pose` is the final pose chosen by this SLAM node:
+
+```text
+if scan matching is accepted:
+    estimated_pose = scan_matched_pose
+else:
+    estimated_pose = odometry-predicted pose
+```
+
+This first version does not blend odometry and scan matching with a Kalman filter. It uses the simpler rule above because it is easier to inspect and understand.
+
+## Reused Methods From Existing Packages
+
+From `mapping`, this package reuses the ideas of:
+
+- occupancy grid maps
+- log-odds map updates
+- Bresenham ray tracing
+- marking cells along a beam as free
+- marking the laser hit cell as occupied
+- publishing `/map`
+
+From `localization`, this package reuses the ideas of:
+
+- local scan matching around a predicted pose
+- likelihood field scoring
+- publishing `/estimated_pose`
+- publishing the `map -> odom` transform
+
+The new part is the SLAM loop:
+
+```text
+predict pose from odometry
+correct pose with scan matching
+update the map with the corrected pose
+```
+
+## Terminal Output
+
+The node prints a small throttled summary while scans are integrated:
+
+```text
+SLAM integrated=... stationary_skipped=... pose=(x, y, theta) match=yes/no score=... occupied=...
+```
+
+Meaning:
+
+- `integrated`: scans inserted into the map
+- `stationary_skipped`: scans ignored because the robot did not move enough
+- `pose`: current estimated pose
+- `match`: whether scan matching corrected the pose
+- `score`: scan matching score
+- `occupied`: occupied cells in the current map
+
+When the robot is not moving, scan matching and map updates are skipped after the first scan. This keeps the node from repeatedly inserting the same scan and making the map over-confident.
+
+## Current Limits
+
+This is not full SLAM yet.
+
+Current limits:
+
+- no loop closure
+- no pose graph
+- no graph optimization
+- no global relocalization
+- no map rebuilding after old pose corrections
+- tuning values are still hard-coded
+
+It can correct small odometry errors, but it cannot fix large drift yet.
+
+## Future Stages
+
+Stage 3: store trajectory history.
+
+- save past robot poses
+- publish the robot path
+- make it easier to see drift over time
+
+Stage 4: detect loop closure.
+
+- notice when the robot returns to a place it has seen before
+- compare current scans with old map areas or old scans
+
+Stage 5: pose graph optimization.
+
+- treat old poses as nodes in a graph
+- add movement and loop-closure constraints
+- adjust old poses so the full path becomes more consistent
+
+Stage 6: rebuild or correct the map.
+
+- after old poses are corrected, rebuild the map using corrected poses
+- this is how SLAM can fix a bent map after loop closure
+
+## Run
+
+Build from the workspace root:
+
+```bash
+cd ~/workspace/gazebo_ws
+colcon build --packages-select slam
+source install/setup.bash
+```
+
+Start simulation:
+
+```bash
+ros2 launch simulation bringup_simulation.launch.py
+```
+
+Start SLAM:
+
+```bash
+ros2 launch slam simple_slam.launch.py
+```
+
+Start teleop:
+
+```bash
+ros2 run teleop_twist_keyboard teleop_twist_keyboard
+```
+
+Start RViz:
+
+```bash
+rviz2
+```
+
+In RViz:
+
+- set Fixed Frame to `map`
+- add `/map`
+- add `/estimated_pose`
+- add `/scan_matched_pose`
+- add `TF`
+
+Drive slowly at first. The map should grow around the robot.

--- a/src/slam/launch/simple_slam.launch.py
+++ b/src/slam/launch/simple_slam.launch.py
@@ -1,0 +1,13 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='slam',
+            executable='simple_slam_node',
+            name='simple_slam_node',
+            output='screen',
+        ),
+    ])

--- a/src/slam/package.xml
+++ b/src/slam/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>slam</name>
+  <version>0.0.0</version>
+  <description>Learning package for simple occupancy-grid SLAM.</description>
+  <maintainer email="tj19970215@gmail.com">jtao</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/slam/src/simple_slam_node.cpp
+++ b/src/slam/src/simple_slam_node.cpp
@@ -36,6 +36,7 @@ struct ScanMatchResult
 struct KeyFrame
 {
     Pose2D pose;
+    Pose2D corrected_pose;
     std::vector<float> scan_signature;
     int scan_index = 0;
 };
@@ -61,11 +62,13 @@ private:
     void publishScanMatchedPose(const Pose2D & pose, const rclcpp::Time & stamp);
     void publishMapToOdomTf(const rclcpp::Time & stamp);
     void updateTrajectory(const rclcpp::Time & stamp);
+    void publishCorrectedTrajectory(const rclcpp::Time & stamp);
     void publishLoopClosurePose(const Pose2D & pose, const rclcpp::Time & stamp);
 
     bool shouldAddKeyFrame() const;
     void addKeyFrame(const sensor_msgs::msg::LaserScan & scan);
-    bool detectLoopClosure(const sensor_msgs::msg::LaserScan & scan, const rclcpp::Time & stamp);
+    bool detectLoopClosure(const rclcpp::Time & stamp);
+    void applyLoopClosureCorrection(std::size_t old_index, std::size_t current_index);
     std::vector<float> makeScanSignature(const sensor_msgs::msg::LaserScan & scan) const;
     double scanSignatureDifference(
         const std::vector<float> & first,
@@ -89,12 +92,14 @@ private:
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr estimated_pose_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr scan_matched_pose_pub_;
     rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr trajectory_pub_;
+    rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr corrected_trajectory_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr loop_closure_pose_pub_;
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
     nav_msgs::msg::OccupancyGrid map_msg_;
     nav_msgs::msg::OccupancyGrid likelihood_field_msg_;
     nav_msgs::msg::Path trajectory_msg_;
+    nav_msgs::msg::Path corrected_trajectory_msg_;
     std::vector<double> map_log_odds_;
     std::vector<KeyFrame> keyframes_;
 
@@ -164,6 +169,8 @@ SimpleSlamNode::SimpleSlamNode()
     scan_matched_pose_pub_ =
         this->create_publisher<geometry_msgs::msg::PoseStamped>("/scan_matched_pose", 10);
     trajectory_pub_ = this->create_publisher<nav_msgs::msg::Path>("/trajectory", 10);
+    corrected_trajectory_pub_ =
+        this->create_publisher<nav_msgs::msg::Path>("/corrected_trajectory", 10);
     loop_closure_pose_pub_ =
         this->create_publisher<geometry_msgs::msg::PoseStamped>("/loop_closure_pose", 10);
 
@@ -172,7 +179,7 @@ SimpleSlamNode::SimpleSlamNode()
     RCLCPP_INFO(this->get_logger(), "Simple SLAM node started.");
     RCLCPP_INFO(
         this->get_logger(),
-        "Inputs: /odom, /scan. Outputs: /map, /estimated_pose, /scan_matched_pose, /trajectory, /loop_closure_pose, TF map->odom.");
+        "Inputs: /odom, /scan. Outputs: /map, /estimated_pose, /scan_matched_pose, /trajectory, /corrected_trajectory, /loop_closure_pose, TF map->odom.");
 }
 
 void SimpleSlamNode::initializeMap()
@@ -195,6 +202,7 @@ void SimpleSlamNode::initializeMap()
     likelihood_field_msg_.data.assign(width_ * height_, 0);
 
     trajectory_msg_.header.frame_id = "map";
+    corrected_trajectory_msg_.header.frame_id = "map";
 }
 
 void SimpleSlamNode::odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
@@ -244,10 +252,11 @@ void SimpleSlamNode::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr m
     scans_integrated_++;
     likelihood_field_dirty_ = true;
     updateTrajectory(msg->header.stamp);
-    detectLoopClosure(*msg, msg->header.stamp);
     if (shouldAddKeyFrame()) {
         addKeyFrame(*msg);
+        detectLoopClosure(msg->header.stamp);
     }
+    publishCorrectedTrajectory(msg->header.stamp);
 
     RCLCPP_INFO_THROTTLE(
         this->get_logger(),
@@ -583,6 +592,25 @@ void SimpleSlamNode::updateTrajectory(const rclcpp::Time & stamp)
     trajectory_pub_->publish(trajectory_msg_);
 }
 
+void SimpleSlamNode::publishCorrectedTrajectory(const rclcpp::Time & stamp)
+{
+    corrected_trajectory_msg_.header.stamp = stamp;
+    corrected_trajectory_msg_.poses.clear();
+    corrected_trajectory_msg_.poses.reserve(keyframes_.size());
+
+    for (const auto & keyframe : keyframes_) {
+        geometry_msgs::msg::PoseStamped pose;
+        pose.header.stamp = stamp;
+        pose.header.frame_id = "map";
+        pose.pose.position.x = keyframe.corrected_pose.x;
+        pose.pose.position.y = keyframe.corrected_pose.y;
+        pose.pose.orientation = yawToQuaternion(keyframe.corrected_pose.theta);
+        corrected_trajectory_msg_.poses.push_back(pose);
+    }
+
+    corrected_trajectory_pub_->publish(corrected_trajectory_msg_);
+}
+
 void SimpleSlamNode::publishLoopClosurePose(const Pose2D & pose, const rclcpp::Time & stamp)
 {
     geometry_msgs::msg::PoseStamped msg;
@@ -610,6 +638,7 @@ void SimpleSlamNode::addKeyFrame(const sensor_msgs::msg::LaserScan & scan)
 {
     KeyFrame keyframe;
     keyframe.pose = slam_pose_;
+    keyframe.corrected_pose = slam_pose_;
     keyframe.scan_signature = makeScanSignature(scan);
     keyframe.scan_index = scans_integrated_;
 
@@ -618,8 +647,7 @@ void SimpleSlamNode::addKeyFrame(const sensor_msgs::msg::LaserScan & scan)
     keyframe_initialized_ = true;
 }
 
-bool SimpleSlamNode::detectLoopClosure(
-    const sensor_msgs::msg::LaserScan & scan, const rclcpp::Time & stamp)
+bool SimpleSlamNode::detectLoopClosure(const rclcpp::Time & stamp)
 {
     if (keyframes_.size() <= static_cast<std::size_t>(min_loop_closure_keyframe_age_)) {
         return false;
@@ -629,30 +657,32 @@ bool SimpleSlamNode::detectLoopClosure(
         return false;
     }
 
-    std::vector<float> current_signature = makeScanSignature(scan);
+    std::size_t current_index = keyframes_.size() - 1;
+    const KeyFrame & current_keyframe = keyframes_[current_index];
     double best_difference = std::numeric_limits<double>::max();
     std::size_t best_index = 0;
     bool found_candidate = false;
 
-    for (std::size_t i = 0; i < keyframes_.size(); ++i) {
+    for (std::size_t i = 0; i < current_index; ++i) {
         const KeyFrame & keyframe = keyframes_[i];
-        int keyframe_age = scans_integrated_ - keyframe.scan_index;
+        int keyframe_age = current_keyframe.scan_index - keyframe.scan_index;
         if (keyframe_age < min_loop_closure_keyframe_age_) {
             continue;
         }
 
-        double distance = poseDistance(slam_pose_, keyframe.pose);
+        double distance = poseDistance(current_keyframe.pose, keyframe.pose);
         if (distance > loop_closure_search_radius_) {
             continue;
         }
 
-        double heading_difference = std::abs(normalizeAngle(slam_pose_.theta - keyframe.pose.theta));
+        double heading_difference =
+            std::abs(normalizeAngle(current_keyframe.pose.theta - keyframe.pose.theta));
         if (heading_difference > loop_closure_max_heading_diff_) {
             continue;
         }
 
         double signature_difference =
-            scanSignatureDifference(current_signature, keyframe.scan_signature);
+            scanSignatureDifference(current_keyframe.scan_signature, keyframe.scan_signature);
         if (signature_difference < best_difference) {
             best_difference = signature_difference;
             best_index = i;
@@ -668,16 +698,43 @@ bool SimpleSlamNode::detectLoopClosure(
     last_loop_closure_scan_ = scans_integrated_;
     const KeyFrame & matched_keyframe = keyframes_[best_index];
     publishLoopClosurePose(matched_keyframe.pose, stamp);
+    applyLoopClosureCorrection(best_index, current_index);
+    publishCorrectedTrajectory(stamp);
 
     RCLCPP_INFO(
         this->get_logger(),
-        "Loop closure detected: current_scan=%d matched_keyframe=%zu old_scan=%d signature_diff=%.3f",
+        "Loop closure detected: current_scan=%d current_keyframe=%zu matched_keyframe=%zu old_scan=%d signature_diff=%.3f",
         scans_integrated_,
+        current_index,
         best_index,
         matched_keyframe.scan_index,
         best_difference);
 
     return true;
+}
+
+void SimpleSlamNode::applyLoopClosureCorrection(
+    std::size_t old_index, std::size_t current_index)
+{
+    if (current_index <= old_index || current_index >= keyframes_.size()) {
+        return;
+    }
+
+    const Pose2D old_pose = keyframes_[old_index].corrected_pose;
+    const Pose2D current_pose = keyframes_[current_index].corrected_pose;
+
+    double error_x = old_pose.x - current_pose.x;
+    double error_y = old_pose.y - current_pose.y;
+    double error_theta = normalizeAngle(old_pose.theta - current_pose.theta);
+    double span = static_cast<double>(current_index - old_index);
+
+    for (std::size_t i = old_index + 1; i <= current_index; ++i) {
+        double fraction = static_cast<double>(i - old_index) / span;
+        keyframes_[i].corrected_pose.x += fraction * error_x;
+        keyframes_[i].corrected_pose.y += fraction * error_y;
+        keyframes_[i].corrected_pose.theta =
+            normalizeAngle(keyframes_[i].corrected_pose.theta + fraction * error_theta);
+    }
 }
 
 std::vector<float> SimpleSlamNode::makeScanSignature(

--- a/src/slam/src/simple_slam_node.cpp
+++ b/src/slam/src/simple_slam_node.cpp
@@ -157,12 +157,12 @@ private:
     double search_theta_step_ = 0.04;
     std::size_t scan_match_beam_step_ = 10;
     double min_scan_match_score_ = 0.20;
-    double min_scan_match_score_improvement_ = 0.05;
+    double min_scan_match_score_improvement_ = 0.003;
     double max_scan_match_translation_correction_ = 0.08;
     double max_scan_match_rotation_correction_ = 0.08;
-    double min_scan_match_translation_interval_ = 0.05;
-    double min_scan_match_rotation_interval_ = 0.05;
-    int min_scan_match_scan_gap_ = 5;
+    double min_scan_match_translation_interval_ = 0.02;
+    double min_scan_match_rotation_interval_ = 0.02;
+    int min_scan_match_scan_gap_ = 2;
     double min_update_translation_ = 0.01;
     double min_update_rotation_ = 0.01;
 

--- a/src/slam/src/simple_slam_node.cpp
+++ b/src/slam/src/simple_slam_node.cpp
@@ -33,11 +33,21 @@ struct ScanMatchResult
     bool used_scan_matching = false;
 };
 
+struct StoredScan
+{
+    std::vector<float> ranges;
+    float angle_min = 0.0F;
+    float angle_increment = 0.0F;
+    float range_min = 0.0F;
+    float range_max = 0.0F;
+};
+
 struct KeyFrame
 {
     Pose2D pose;
     Pose2D corrected_pose;
     std::vector<float> scan_signature;
+    StoredScan scan;
     int scan_index = 0;
 };
 
@@ -57,7 +67,13 @@ private:
     double likelihoodAtWorld(double x, double y) const;
 
     void updateMapWithScan(const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose);
+    void insertScanIntoLogOddsMap(
+        const StoredScan & scan,
+        const Pose2D & pose,
+        std::vector<double> & log_odds_map);
+    void rebuildCorrectedMap(const rclcpp::Time & stamp);
     void publishMap();
+    void publishCorrectedMap(const rclcpp::Time & stamp);
     void publishEstimatedPose(const rclcpp::Time & stamp);
     void publishScanMatchedPose(const Pose2D & pose, const rclcpp::Time & stamp);
     void publishMapToOdomTf(const rclcpp::Time & stamp);
@@ -70,6 +86,7 @@ private:
     bool detectLoopClosure(const rclcpp::Time & stamp);
     bool shouldApplyLoopClosureCorrection(std::size_t old_index, std::size_t current_index) const;
     void applyLoopClosureCorrection(std::size_t old_index, std::size_t current_index);
+    StoredScan makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const;
     std::vector<float> makeScanSignature(const sensor_msgs::msg::LaserScan & scan) const;
     double scanSignatureDifference(
         const std::vector<float> & first,
@@ -90,6 +107,7 @@ private:
     rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
     rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
     rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_pub_;
+    rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr corrected_map_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr estimated_pose_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr scan_matched_pose_pub_;
     rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr trajectory_pub_;
@@ -98,10 +116,12 @@ private:
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
     nav_msgs::msg::OccupancyGrid map_msg_;
+    nav_msgs::msg::OccupancyGrid corrected_map_msg_;
     nav_msgs::msg::OccupancyGrid likelihood_field_msg_;
     nav_msgs::msg::Path trajectory_msg_;
     nav_msgs::msg::Path corrected_trajectory_msg_;
     std::vector<double> map_log_odds_;
+    std::vector<double> corrected_map_log_odds_;
     std::vector<KeyFrame> keyframes_;
 
     Pose2D slam_pose_;
@@ -172,6 +192,8 @@ SimpleSlamNode::SimpleSlamNode()
 
     auto map_qos = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();
     map_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("/map", map_qos);
+    corrected_map_pub_ =
+        this->create_publisher<nav_msgs::msg::OccupancyGrid>("/corrected_map", map_qos);
     estimated_pose_pub_ =
         this->create_publisher<geometry_msgs::msg::PoseStamped>("/estimated_pose", 10);
     scan_matched_pose_pub_ =
@@ -187,7 +209,7 @@ SimpleSlamNode::SimpleSlamNode()
     RCLCPP_INFO(this->get_logger(), "Simple SLAM node started.");
     RCLCPP_INFO(
         this->get_logger(),
-        "Inputs: /odom, /scan. Outputs: /map, /estimated_pose, /scan_matched_pose, /trajectory, /corrected_trajectory, /loop_closure_pose, TF map->odom.");
+        "Inputs: /odom, /scan. Outputs: /map, /corrected_map, /estimated_pose, /scan_matched_pose, /trajectory, /corrected_trajectory, /loop_closure_pose, TF map->odom.");
 }
 
 void SimpleSlamNode::initializeMap()
@@ -196,6 +218,7 @@ void SimpleSlamNode::initializeMap()
     origin_y_ = -height_ * resolution_ / 2.0;
 
     map_log_odds_.assign(width_ * height_, 0.0);
+    corrected_map_log_odds_.assign(width_ * height_, 0.0);
 
     map_msg_.header.frame_id = "map";
     map_msg_.info.resolution = resolution_;
@@ -205,6 +228,7 @@ void SimpleSlamNode::initializeMap()
     map_msg_.info.origin.position.y = origin_y_;
     map_msg_.info.origin.orientation.w = 1.0;
     map_msg_.data.assign(width_ * height_, -1);
+    corrected_map_msg_ = map_msg_;
 
     likelihood_field_msg_ = map_msg_;
     likelihood_field_msg_.data.assign(width_ * height_, 0);
@@ -470,6 +494,14 @@ double SimpleSlamNode::likelihoodAtWorld(double x, double y) const
 void SimpleSlamNode::updateMapWithScan(
     const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose)
 {
+    insertScanIntoLogOddsMap(makeStoredScan(scan), pose, map_log_odds_);
+}
+
+void SimpleSlamNode::insertScanIntoLogOddsMap(
+    const StoredScan & scan,
+    const Pose2D & pose,
+    std::vector<double> & log_odds_map)
+{
     int robot_grid_x = 0;
     int robot_grid_y = 0;
     worldToGrid(pose.x, pose.y, robot_grid_x, robot_grid_y);
@@ -507,14 +539,28 @@ void SimpleSlamNode::updateMapWithScan(
             int x = cells[cell_index].first;
             int y = cells[cell_index].second;
             int index = y * width_ + x;
-            map_log_odds_[index] =
-                clamp(map_log_odds_[index] + log_odds_free_, log_odds_min_, log_odds_max_);
+            log_odds_map[index] =
+                clamp(log_odds_map[index] + log_odds_free_, log_odds_min_, log_odds_max_);
         }
 
         int hit_index = cells.back().second * width_ + cells.back().first;
-        map_log_odds_[hit_index] =
-            clamp(map_log_odds_[hit_index] + log_odds_hit_, log_odds_min_, log_odds_max_);
+        log_odds_map[hit_index] =
+            clamp(log_odds_map[hit_index] + log_odds_hit_, log_odds_min_, log_odds_max_);
     }
+}
+
+void SimpleSlamNode::rebuildCorrectedMap(const rclcpp::Time & stamp)
+{
+    corrected_map_log_odds_.assign(width_ * height_, 0.0);
+
+    for (const auto & keyframe : keyframes_) {
+        insertScanIntoLogOddsMap(
+            keyframe.scan,
+            keyframe.corrected_pose,
+            corrected_map_log_odds_);
+    }
+
+    publishCorrectedMap(stamp);
 }
 
 void SimpleSlamNode::publishMap()
@@ -537,6 +583,23 @@ void SimpleSlamNode::publishMap()
     }
 
     map_pub_->publish(map_msg_);
+}
+
+void SimpleSlamNode::publishCorrectedMap(const rclcpp::Time & stamp)
+{
+    corrected_map_msg_.header.stamp = stamp;
+
+    for (int i = 0; i < width_ * height_; ++i) {
+        double probability = 1.0 / (1.0 + std::exp(-corrected_map_log_odds_[i]));
+
+        if (corrected_map_log_odds_[i] == 0.0) {
+            corrected_map_msg_.data[i] = -1;
+        } else {
+            corrected_map_msg_.data[i] = static_cast<int8_t>(std::round(probability * 100.0));
+        }
+    }
+
+    corrected_map_pub_->publish(corrected_map_msg_);
 }
 
 void SimpleSlamNode::publishEstimatedPose(const rclcpp::Time & stamp)
@@ -649,6 +712,7 @@ void SimpleSlamNode::addKeyFrame(const sensor_msgs::msg::LaserScan & scan)
     keyframe.pose = slam_pose_;
     keyframe.corrected_pose = slam_pose_;
     keyframe.scan_signature = makeScanSignature(scan);
+    keyframe.scan = makeStoredScan(scan);
     keyframe.scan_index = scans_integrated_;
 
     keyframes_.push_back(keyframe);
@@ -712,6 +776,7 @@ bool SimpleSlamNode::detectLoopClosure(const rclcpp::Time & stamp)
     if (shouldApplyLoopClosureCorrection(best_index, current_index)) {
         applyLoopClosureCorrection(best_index, current_index);
         publishCorrectedTrajectory(stamp);
+        rebuildCorrectedMap(stamp);
         correction_applied = true;
     }
 
@@ -784,6 +849,17 @@ void SimpleSlamNode::applyLoopClosureCorrection(
     loop_closure_correction_count_++;
     last_correction_scan_ = scans_integrated_;
     last_corrected_old_keyframe_ = old_index;
+}
+
+StoredScan SimpleSlamNode::makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const
+{
+    StoredScan stored_scan;
+    stored_scan.ranges = scan.ranges;
+    stored_scan.angle_min = scan.angle_min;
+    stored_scan.angle_increment = scan.angle_increment;
+    stored_scan.range_min = scan.range_min;
+    stored_scan.range_max = scan.range_max;
+    return stored_scan;
 }
 
 std::vector<float> SimpleSlamNode::makeScanSignature(

--- a/src/slam/src/simple_slam_node.cpp
+++ b/src/slam/src/simple_slam_node.cpp
@@ -1,0 +1,625 @@
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2/LinearMath/Transform.h"
+#include "tf2/utils.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2_ros/transform_broadcaster.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <queue>
+#include <utility>
+#include <vector>
+
+struct Pose2D
+{
+    double x = 0.0;
+    double y = 0.0;
+    double theta = 0.0;
+};
+
+struct ScanMatchResult
+{
+    Pose2D pose;
+    double score = 0.0;
+    bool used_scan_matching = false;
+};
+
+class SimpleSlamNode : public rclcpp::Node
+{
+public:
+    SimpleSlamNode();
+
+private:
+    void odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
+    void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
+
+    void initializeMap();
+    void rebuildLikelihoodField();
+    ScanMatchResult matchScan(const sensor_msgs::msg::LaserScan & scan, const Pose2D & predicted);
+    double scoreScanAtPose(const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose) const;
+    double likelihoodAtWorld(double x, double y) const;
+
+    void updateMapWithScan(const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose);
+    void publishMap();
+    void publishEstimatedPose(const rclcpp::Time & stamp);
+    void publishScanMatchedPose(const Pose2D & pose, const rclcpp::Time & stamp);
+    void publishMapToOdomTf(const rclcpp::Time & stamp);
+
+    Pose2D odomMsgToPose(const nav_msgs::msg::Odometry & msg) const;
+    Pose2D applyOdomDeltaToSlamPose(const Pose2D & old_odom, const Pose2D & new_odom) const;
+    bool odomMovedEnough(const Pose2D & old_odom, const Pose2D & new_odom) const;
+    geometry_msgs::msg::Quaternion yawToQuaternion(double yaw) const;
+
+    void worldToGrid(double wx, double wy, int & gx, int & gy) const;
+    bool isValidCell(int x, int y) const;
+    std::vector<std::pair<int, int>> bresenhamLine(int x0, int y0, int x1, int y1) const;
+    double normalizeAngle(double angle) const;
+    double clamp(double value, double low, double high) const;
+
+    rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+    rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
+    rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr estimated_pose_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr scan_matched_pose_pub_;
+    std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+
+    nav_msgs::msg::OccupancyGrid map_msg_;
+    nav_msgs::msg::OccupancyGrid likelihood_field_msg_;
+    std::vector<double> map_log_odds_;
+
+    Pose2D slam_pose_;
+    Pose2D last_odom_pose_;
+    Pose2D current_odom_pose_;
+    bool odom_initialized_ = false;
+    bool scan_received_ = false;
+
+    double resolution_ = 0.05;
+    int width_ = 500;
+    int height_ = 500;
+    double origin_x_ = -12.5;
+    double origin_y_ = -12.5;
+
+    double log_odds_hit_ = 2.89;
+    double log_odds_free_ = -2.25;
+    double log_odds_min_ = -10.0;
+    double log_odds_max_ = 10.0;
+
+    int occupied_cell_count_ = 0;
+    int min_occupied_cells_for_matching_ = 80;
+    bool likelihood_field_dirty_ = true;
+    double likelihood_max_distance_ = 1.0;
+
+    double search_xy_range_ = 0.15;
+    double search_xy_step_ = 0.05;
+    double search_theta_range_ = 0.17;
+    double search_theta_step_ = 0.085;
+    std::size_t scan_match_beam_step_ = 10;
+    double min_scan_match_score_ = 0.20;
+    double min_update_translation_ = 0.01;
+    double min_update_rotation_ = 0.01;
+
+    int scans_integrated_ = 0;
+    int stationary_scans_skipped_ = 0;
+};
+
+SimpleSlamNode::SimpleSlamNode()
+: Node("simple_slam_node")
+{
+    initializeMap();
+
+    odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+        "/odom", 10, std::bind(&SimpleSlamNode::odomCallback, this, std::placeholders::_1));
+
+    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>(
+        "/scan", 10, std::bind(&SimpleSlamNode::scanCallback, this, std::placeholders::_1));
+
+    auto map_qos = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();
+    map_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("/map", map_qos);
+    estimated_pose_pub_ =
+        this->create_publisher<geometry_msgs::msg::PoseStamped>("/estimated_pose", 10);
+    scan_matched_pose_pub_ =
+        this->create_publisher<geometry_msgs::msg::PoseStamped>("/scan_matched_pose", 10);
+
+    tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
+
+    RCLCPP_INFO(this->get_logger(), "Simple SLAM node started.");
+    RCLCPP_INFO(
+        this->get_logger(),
+        "Inputs: /odom, /scan. Outputs: /map, /estimated_pose, /scan_matched_pose, TF map->odom.");
+}
+
+void SimpleSlamNode::initializeMap()
+{
+    origin_x_ = -width_ * resolution_ / 2.0;
+    origin_y_ = -height_ * resolution_ / 2.0;
+
+    map_log_odds_.assign(width_ * height_, 0.0);
+
+    map_msg_.header.frame_id = "map";
+    map_msg_.info.resolution = resolution_;
+    map_msg_.info.width = width_;
+    map_msg_.info.height = height_;
+    map_msg_.info.origin.position.x = origin_x_;
+    map_msg_.info.origin.position.y = origin_y_;
+    map_msg_.info.origin.orientation.w = 1.0;
+    map_msg_.data.assign(width_ * height_, -1);
+
+    likelihood_field_msg_ = map_msg_;
+    likelihood_field_msg_.data.assign(width_ * height_, 0);
+}
+
+void SimpleSlamNode::odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+{
+    current_odom_pose_ = odomMsgToPose(*msg);
+
+    if (!odom_initialized_) {
+        last_odom_pose_ = current_odom_pose_;
+        odom_initialized_ = true;
+        publishEstimatedPose(msg->header.stamp);
+        publishMapToOdomTf(msg->header.stamp);
+        RCLCPP_INFO(this->get_logger(), "First odom received. SLAM pose starts at map origin.");
+    }
+}
+
+void SimpleSlamNode::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
+{
+    if (!odom_initialized_) {
+        RCLCPP_WARN_THROTTLE(
+            this->get_logger(), *this->get_clock(), 2000, "Waiting for /odom before using scans.");
+        return;
+    }
+
+    bool moved_enough = odomMovedEnough(last_odom_pose_, current_odom_pose_);
+    Pose2D predicted_pose = applyOdomDeltaToSlamPose(last_odom_pose_, current_odom_pose_);
+    last_odom_pose_ = current_odom_pose_;
+
+    if (scan_received_ && !moved_enough) {
+        stationary_scans_skipped_++;
+        publishEstimatedPose(msg->header.stamp);
+        publishMapToOdomTf(msg->header.stamp);
+        return;
+    }
+
+    ScanMatchResult result = matchScan(*msg, predicted_pose);
+    slam_pose_ = result.pose;
+
+    updateMapWithScan(*msg, slam_pose_);
+    publishMap();
+    publishEstimatedPose(msg->header.stamp);
+    if (result.used_scan_matching) {
+        publishScanMatchedPose(result.pose, msg->header.stamp);
+    }
+    publishMapToOdomTf(msg->header.stamp);
+
+    scan_received_ = true;
+    scans_integrated_++;
+    likelihood_field_dirty_ = true;
+
+    RCLCPP_INFO_THROTTLE(
+        this->get_logger(),
+        *this->get_clock(),
+        5000,
+        "SLAM integrated=%d stationary_skipped=%d pose=(%.2f, %.2f, %.2f) match=%s score=%.3f occupied=%d",
+        scans_integrated_,
+        stationary_scans_skipped_,
+        slam_pose_.x,
+        slam_pose_.y,
+        slam_pose_.theta,
+        result.used_scan_matching ? "yes" : "no",
+        result.score,
+        occupied_cell_count_);
+}
+
+Pose2D SimpleSlamNode::applyOdomDeltaToSlamPose(
+    const Pose2D & old_odom, const Pose2D & new_odom) const
+{
+    double odom_dx = new_odom.x - old_odom.x;
+    double odom_dy = new_odom.y - old_odom.y;
+    double old_odom_theta = old_odom.theta;
+
+    double local_dx =
+        std::cos(old_odom_theta) * odom_dx + std::sin(old_odom_theta) * odom_dy;
+    double local_dy =
+        -std::sin(old_odom_theta) * odom_dx + std::cos(old_odom_theta) * odom_dy;
+    double local_dtheta = normalizeAngle(new_odom.theta - old_odom.theta);
+
+    Pose2D predicted = slam_pose_;
+    predicted.x += std::cos(slam_pose_.theta) * local_dx -
+        std::sin(slam_pose_.theta) * local_dy;
+    predicted.y += std::sin(slam_pose_.theta) * local_dx +
+        std::cos(slam_pose_.theta) * local_dy;
+    predicted.theta = normalizeAngle(slam_pose_.theta + local_dtheta);
+    return predicted;
+}
+
+ScanMatchResult SimpleSlamNode::matchScan(
+    const sensor_msgs::msg::LaserScan & scan, const Pose2D & predicted)
+{
+    ScanMatchResult result;
+    result.pose = predicted;
+
+    if (!scan_received_) {
+        return result;
+    }
+
+    if (occupied_cell_count_ < min_occupied_cells_for_matching_) {
+        return result;
+    }
+
+    if (likelihood_field_dirty_) {
+        rebuildLikelihoodField();
+        likelihood_field_dirty_ = false;
+    }
+
+    double best_score = -std::numeric_limits<double>::infinity();
+    Pose2D best_pose = predicted;
+
+    for (double dx = -search_xy_range_; dx <= search_xy_range_ + 1e-9; dx += search_xy_step_) {
+        for (double dy = -search_xy_range_; dy <= search_xy_range_ + 1e-9; dy += search_xy_step_) {
+            for (double dtheta = -search_theta_range_;
+                dtheta <= search_theta_range_ + 1e-9;
+                dtheta += search_theta_step_)
+            {
+                Pose2D candidate;
+                candidate.x = predicted.x + dx;
+                candidate.y = predicted.y + dy;
+                candidate.theta = normalizeAngle(predicted.theta + dtheta);
+
+                double score = scoreScanAtPose(scan, candidate);
+                if (score > best_score) {
+                    best_score = score;
+                    best_pose = candidate;
+                }
+            }
+        }
+    }
+
+    result.score = std::max(best_score, 0.0);
+
+    if (best_score >= min_scan_match_score_) {
+        result.pose = best_pose;
+        result.used_scan_matching = true;
+    }
+
+    return result;
+}
+
+void SimpleSlamNode::rebuildLikelihoodField()
+{
+    likelihood_field_msg_ = map_msg_;
+    likelihood_field_msg_.data.assign(width_ * height_, 0);
+
+    int max_distance_cells = static_cast<int>(std::ceil(likelihood_max_distance_ / resolution_));
+    std::vector<int> distance_to_wall(width_ * height_, max_distance_cells + 1);
+    std::queue<int> cells_to_visit;
+
+    for (int row = 0; row < height_; ++row) {
+        for (int col = 0; col < width_; ++col) {
+            int index = row * width_ + col;
+            if (map_msg_.data[index] > 50) {
+                distance_to_wall[index] = 0;
+                cells_to_visit.push(index);
+            }
+        }
+    }
+
+    const int neighbor_offsets[4][2] = {
+        {1, 0},
+        {-1, 0},
+        {0, 1},
+        {0, -1}
+    };
+
+    while (!cells_to_visit.empty()) {
+        int index = cells_to_visit.front();
+        cells_to_visit.pop();
+
+        int row = index / width_;
+        int col = index % width_;
+        int next_distance = distance_to_wall[index] + 1;
+
+        if (next_distance > max_distance_cells) {
+            continue;
+        }
+
+        for (const auto & offset : neighbor_offsets) {
+            int next_col = col + offset[0];
+            int next_row = row + offset[1];
+
+            if (!isValidCell(next_col, next_row)) {
+                continue;
+            }
+
+            int next_index = next_row * width_ + next_col;
+            if (next_distance >= distance_to_wall[next_index]) {
+                continue;
+            }
+
+            distance_to_wall[next_index] = next_distance;
+            cells_to_visit.push(next_index);
+        }
+    }
+
+    for (int i = 0; i < width_ * height_; ++i) {
+        if (distance_to_wall[i] > max_distance_cells) {
+            continue;
+        }
+
+        double distance_m = distance_to_wall[i] * resolution_;
+        double likelihood = 1.0 - std::min(distance_m / likelihood_max_distance_, 1.0);
+        likelihood_field_msg_.data[i] = static_cast<int8_t>(std::round(likelihood * 100.0));
+    }
+}
+
+double SimpleSlamNode::scoreScanAtPose(
+    const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose) const
+{
+    double score = 0.0;
+    int used_beams = 0;
+
+    for (std::size_t i = 0; i < scan.ranges.size(); i += scan_match_beam_step_) {
+        float range = scan.ranges[i];
+
+        if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
+            continue;
+        }
+
+        double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
+        double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
+        double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
+
+        score += likelihoodAtWorld(hit_x, hit_y);
+        used_beams++;
+    }
+
+    if (used_beams == 0) {
+        return 0.0;
+    }
+
+    return score / used_beams;
+}
+
+double SimpleSlamNode::likelihoodAtWorld(double x, double y) const
+{
+    int col = 0;
+    int row = 0;
+    worldToGrid(x, y, col, row);
+
+    if (!isValidCell(col, row)) {
+        return 0.0;
+    }
+
+    int index = row * width_ + col;
+    return likelihood_field_msg_.data[index] / 100.0;
+}
+
+void SimpleSlamNode::updateMapWithScan(
+    const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose)
+{
+    int robot_grid_x = 0;
+    int robot_grid_y = 0;
+    worldToGrid(pose.x, pose.y, robot_grid_x, robot_grid_y);
+
+    if (!isValidCell(robot_grid_x, robot_grid_y)) {
+        RCLCPP_WARN(this->get_logger(), "SLAM pose outside map bounds; scan skipped.");
+        return;
+    }
+
+    for (std::size_t i = 0; i < scan.ranges.size(); ++i) {
+        float range = scan.ranges[i];
+
+        if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
+            continue;
+        }
+
+        double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
+        double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
+        double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
+
+        int hit_grid_x = 0;
+        int hit_grid_y = 0;
+        worldToGrid(hit_x, hit_y, hit_grid_x, hit_grid_y);
+
+        if (!isValidCell(hit_grid_x, hit_grid_y)) {
+            continue;
+        }
+
+        auto cells = bresenhamLine(robot_grid_x, robot_grid_y, hit_grid_x, hit_grid_y);
+        if (cells.empty()) {
+            continue;
+        }
+
+        for (std::size_t cell_index = 0; cell_index + 1 < cells.size(); ++cell_index) {
+            int x = cells[cell_index].first;
+            int y = cells[cell_index].second;
+            int index = y * width_ + x;
+            map_log_odds_[index] =
+                clamp(map_log_odds_[index] + log_odds_free_, log_odds_min_, log_odds_max_);
+        }
+
+        int hit_index = cells.back().second * width_ + cells.back().first;
+        map_log_odds_[hit_index] =
+            clamp(map_log_odds_[hit_index] + log_odds_hit_, log_odds_min_, log_odds_max_);
+    }
+}
+
+void SimpleSlamNode::publishMap()
+{
+    map_msg_.header.stamp = this->now();
+    occupied_cell_count_ = 0;
+
+    for (int i = 0; i < width_ * height_; ++i) {
+        double probability = 1.0 / (1.0 + std::exp(-map_log_odds_[i]));
+
+        if (map_log_odds_[i] == 0.0) {
+            map_msg_.data[i] = -1;
+        } else {
+            map_msg_.data[i] = static_cast<int8_t>(std::round(probability * 100.0));
+        }
+
+        if (map_msg_.data[i] > 50) {
+            occupied_cell_count_++;
+        }
+    }
+
+    map_pub_->publish(map_msg_);
+}
+
+void SimpleSlamNode::publishEstimatedPose(const rclcpp::Time & stamp)
+{
+    geometry_msgs::msg::PoseStamped msg;
+    msg.header.stamp = stamp;
+    msg.header.frame_id = "map";
+    msg.pose.position.x = slam_pose_.x;
+    msg.pose.position.y = slam_pose_.y;
+    msg.pose.orientation = yawToQuaternion(slam_pose_.theta);
+    estimated_pose_pub_->publish(msg);
+}
+
+void SimpleSlamNode::publishScanMatchedPose(const Pose2D & pose, const rclcpp::Time & stamp)
+{
+    geometry_msgs::msg::PoseStamped msg;
+    msg.header.stamp = stamp;
+    msg.header.frame_id = "map";
+    msg.pose.position.x = pose.x;
+    msg.pose.position.y = pose.y;
+    msg.pose.orientation = yawToQuaternion(pose.theta);
+    scan_matched_pose_pub_->publish(msg);
+}
+
+void SimpleSlamNode::publishMapToOdomTf(const rclcpp::Time & stamp)
+{
+    tf2::Quaternion map_to_base_rotation;
+    map_to_base_rotation.setRPY(0.0, 0.0, slam_pose_.theta);
+
+    tf2::Transform map_to_base;
+    map_to_base.setOrigin(tf2::Vector3(slam_pose_.x, slam_pose_.y, 0.0));
+    map_to_base.setRotation(map_to_base_rotation);
+
+    tf2::Quaternion odom_to_base_rotation;
+    odom_to_base_rotation.setRPY(0.0, 0.0, current_odom_pose_.theta);
+
+    tf2::Transform odom_to_base;
+    odom_to_base.setOrigin(tf2::Vector3(current_odom_pose_.x, current_odom_pose_.y, 0.0));
+    odom_to_base.setRotation(odom_to_base_rotation);
+
+    tf2::Transform map_to_odom = map_to_base * odom_to_base.inverse();
+
+    geometry_msgs::msg::TransformStamped msg;
+    msg.header.stamp = stamp;
+    msg.header.frame_id = "map";
+    msg.child_frame_id = "odom";
+    msg.transform = tf2::toMsg(map_to_odom);
+    tf_broadcaster_->sendTransform(msg);
+}
+
+Pose2D SimpleSlamNode::odomMsgToPose(const nav_msgs::msg::Odometry & msg) const
+{
+    Pose2D pose;
+    pose.x = msg.pose.pose.position.x;
+    pose.y = msg.pose.pose.position.y;
+    pose.theta = tf2::getYaw(msg.pose.pose.orientation);
+    return pose;
+}
+
+bool SimpleSlamNode::odomMovedEnough(const Pose2D & old_odom, const Pose2D & new_odom) const
+{
+    double dx = new_odom.x - old_odom.x;
+    double dy = new_odom.y - old_odom.y;
+    double translation = std::sqrt(dx * dx + dy * dy);
+    double rotation = std::abs(normalizeAngle(new_odom.theta - old_odom.theta));
+
+    return translation >= min_update_translation_ || rotation >= min_update_rotation_;
+}
+
+geometry_msgs::msg::Quaternion SimpleSlamNode::yawToQuaternion(double yaw) const
+{
+    tf2::Quaternion quaternion;
+    quaternion.setRPY(0.0, 0.0, yaw);
+
+    geometry_msgs::msg::Quaternion msg;
+    msg.x = quaternion.x();
+    msg.y = quaternion.y();
+    msg.z = quaternion.z();
+    msg.w = quaternion.w();
+    return msg;
+}
+
+void SimpleSlamNode::worldToGrid(double wx, double wy, int & gx, int & gy) const
+{
+    gx = static_cast<int>(std::floor((wx - origin_x_) / resolution_));
+    gy = static_cast<int>(std::floor((wy - origin_y_) / resolution_));
+}
+
+bool SimpleSlamNode::isValidCell(int x, int y) const
+{
+    return x >= 0 && x < width_ && y >= 0 && y < height_;
+}
+
+std::vector<std::pair<int, int>> SimpleSlamNode::bresenhamLine(
+    int x0, int y0, int x1, int y1) const
+{
+    std::vector<std::pair<int, int>> cells;
+
+    int dx = std::abs(x1 - x0);
+    int dy = std::abs(y1 - y0);
+    int sx = x0 < x1 ? 1 : -1;
+    int sy = y0 < y1 ? 1 : -1;
+    int err = dx - dy;
+
+    int x = x0;
+    int y = y0;
+
+    while (true) {
+        cells.push_back({x, y});
+
+        if (x == x1 && y == y1) {
+            break;
+        }
+
+        int e2 = 2 * err;
+        if (e2 > -dy) {
+            err -= dy;
+            x += sx;
+        }
+        if (e2 < dx) {
+            err += dx;
+            y += sy;
+        }
+    }
+
+    return cells;
+}
+
+double SimpleSlamNode::normalizeAngle(double angle) const
+{
+    while (angle > M_PI) {
+        angle -= 2.0 * M_PI;
+    }
+    while (angle < -M_PI) {
+        angle += 2.0 * M_PI;
+    }
+    return angle;
+}
+
+double SimpleSlamNode::clamp(double value, double low, double high) const
+{
+    return std::min(std::max(value, low), high);
+}
+
+int main(int argc, char ** argv)
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<SimpleSlamNode>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/slam/src/simple_slam_node.cpp
+++ b/src/slam/src/simple_slam_node.cpp
@@ -30,6 +30,7 @@ struct ScanMatchResult
 {
     Pose2D pose;
     double score = 0.0;
+    double predicted_score = 0.0;
     bool used_scan_matching = false;
 };
 
@@ -128,9 +129,11 @@ private:
     Pose2D last_odom_pose_;
     Pose2D current_odom_pose_;
     Pose2D last_keyframe_pose_;
+    Pose2D last_scan_match_pose_;
     bool odom_initialized_ = false;
     bool scan_received_ = false;
     bool keyframe_initialized_ = false;
+    bool scan_match_pose_initialized_ = false;
 
     double resolution_ = 0.05;
     int width_ = 500;
@@ -144,16 +147,22 @@ private:
     double log_odds_max_ = 10.0;
 
     int occupied_cell_count_ = 0;
-    int min_occupied_cells_for_matching_ = 80;
+    int min_occupied_cells_for_matching_ = 250;
     bool likelihood_field_dirty_ = true;
     double likelihood_max_distance_ = 1.0;
 
-    double search_xy_range_ = 0.15;
+    double search_xy_range_ = 0.10;
     double search_xy_step_ = 0.05;
-    double search_theta_range_ = 0.17;
-    double search_theta_step_ = 0.085;
+    double search_theta_range_ = 0.08;
+    double search_theta_step_ = 0.04;
     std::size_t scan_match_beam_step_ = 10;
     double min_scan_match_score_ = 0.20;
+    double min_scan_match_score_improvement_ = 0.05;
+    double max_scan_match_translation_correction_ = 0.08;
+    double max_scan_match_rotation_correction_ = 0.08;
+    double min_scan_match_translation_interval_ = 0.05;
+    double min_scan_match_rotation_interval_ = 0.05;
+    int min_scan_match_scan_gap_ = 5;
     double min_update_translation_ = 0.01;
     double min_update_rotation_ = 0.01;
 
@@ -172,8 +181,10 @@ private:
 
     int scans_integrated_ = 0;
     int stationary_scans_skipped_ = 0;
+    int scan_match_used_count_ = 0;
     int loop_closure_count_ = 0;
     int loop_closure_correction_count_ = 0;
+    int last_scan_match_scan_ = -100000;
     int last_loop_closure_scan_ = -100000;
     int last_correction_scan_ = -100000;
     std::size_t last_corrected_old_keyframe_ = std::numeric_limits<std::size_t>::max();
@@ -294,9 +305,10 @@ void SimpleSlamNode::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr m
         this->get_logger(),
         *this->get_clock(),
         5000,
-        "SLAM integrated=%d stationary_skipped=%d keyframes=%zu loops=%d corrections=%d pose=(%.2f, %.2f, %.2f) match=%s score=%.3f occupied=%d",
+        "SLAM integrated=%d stationary_skipped=%d scan_match_used=%d keyframes=%zu loops=%d corrections=%d pose=(%.2f, %.2f, %.2f) match=%s score=%.3f predicted_score=%.3f occupied=%d",
         scans_integrated_,
         stationary_scans_skipped_,
+        scan_match_used_count_,
         keyframes_.size(),
         loop_closure_count_,
         loop_closure_correction_count_,
@@ -305,6 +317,7 @@ void SimpleSlamNode::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr m
         slam_pose_.theta,
         result.used_scan_matching ? "yes" : "no",
         result.score,
+        result.predicted_score,
         occupied_cell_count_);
 }
 
@@ -340,14 +353,31 @@ ScanMatchResult SimpleSlamNode::matchScan(
         return result;
     }
 
+    if (scans_integrated_ - last_scan_match_scan_ < min_scan_match_scan_gap_) {
+        return result;
+    }
+
     if (occupied_cell_count_ < min_occupied_cells_for_matching_) {
         return result;
+    }
+
+    if (scan_match_pose_initialized_) {
+        double distance_since_last_match = poseDistance(predicted, last_scan_match_pose_);
+        double rotation_since_last_match =
+            std::abs(normalizeAngle(predicted.theta - last_scan_match_pose_.theta));
+        if (distance_since_last_match < min_scan_match_translation_interval_ &&
+            rotation_since_last_match < min_scan_match_rotation_interval_)
+        {
+            return result;
+        }
     }
 
     if (likelihood_field_dirty_) {
         rebuildLikelihoodField();
         likelihood_field_dirty_ = false;
     }
+
+    result.predicted_score = scoreScanAtPose(scan, predicted);
 
     double best_score = -std::numeric_limits<double>::infinity();
     Pose2D best_pose = predicted;
@@ -374,9 +404,22 @@ ScanMatchResult SimpleSlamNode::matchScan(
 
     result.score = std::max(best_score, 0.0);
 
-    if (best_score >= min_scan_match_score_) {
+    double correction_translation = poseDistance(best_pose, predicted);
+    double correction_rotation =
+        std::abs(normalizeAngle(best_pose.theta - predicted.theta));
+    double score_improvement = result.score - result.predicted_score;
+
+    if (best_score >= min_scan_match_score_ &&
+        score_improvement >= min_scan_match_score_improvement_ &&
+        correction_translation <= max_scan_match_translation_correction_ &&
+        correction_rotation <= max_scan_match_rotation_correction_)
+    {
         result.pose = best_pose;
         result.used_scan_matching = true;
+        scan_match_used_count_++;
+        last_scan_match_scan_ = scans_integrated_;
+        last_scan_match_pose_ = result.pose;
+        scan_match_pose_initialized_ = true;
     }
 
     return result;

--- a/src/slam/src/simple_slam_node.cpp
+++ b/src/slam/src/simple_slam_node.cpp
@@ -2,6 +2,7 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "nav_msgs/msg/path.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 
 #include "rclcpp/rclcpp.hpp"
@@ -32,6 +33,13 @@ struct ScanMatchResult
     bool used_scan_matching = false;
 };
 
+struct KeyFrame
+{
+    Pose2D pose;
+    std::vector<float> scan_signature;
+    int scan_index = 0;
+};
+
 class SimpleSlamNode : public rclcpp::Node
 {
 public:
@@ -52,6 +60,17 @@ private:
     void publishEstimatedPose(const rclcpp::Time & stamp);
     void publishScanMatchedPose(const Pose2D & pose, const rclcpp::Time & stamp);
     void publishMapToOdomTf(const rclcpp::Time & stamp);
+    void updateTrajectory(const rclcpp::Time & stamp);
+    void publishLoopClosurePose(const Pose2D & pose, const rclcpp::Time & stamp);
+
+    bool shouldAddKeyFrame() const;
+    void addKeyFrame(const sensor_msgs::msg::LaserScan & scan);
+    bool detectLoopClosure(const sensor_msgs::msg::LaserScan & scan, const rclcpp::Time & stamp);
+    std::vector<float> makeScanSignature(const sensor_msgs::msg::LaserScan & scan) const;
+    double scanSignatureDifference(
+        const std::vector<float> & first,
+        const std::vector<float> & second) const;
+    double poseDistance(const Pose2D & first, const Pose2D & second) const;
 
     Pose2D odomMsgToPose(const nav_msgs::msg::Odometry & msg) const;
     Pose2D applyOdomDeltaToSlamPose(const Pose2D & old_odom, const Pose2D & new_odom) const;
@@ -69,17 +88,23 @@ private:
     rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr estimated_pose_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr scan_matched_pose_pub_;
+    rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr trajectory_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr loop_closure_pose_pub_;
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
     nav_msgs::msg::OccupancyGrid map_msg_;
     nav_msgs::msg::OccupancyGrid likelihood_field_msg_;
+    nav_msgs::msg::Path trajectory_msg_;
     std::vector<double> map_log_odds_;
+    std::vector<KeyFrame> keyframes_;
 
     Pose2D slam_pose_;
     Pose2D last_odom_pose_;
     Pose2D current_odom_pose_;
+    Pose2D last_keyframe_pose_;
     bool odom_initialized_ = false;
     bool scan_received_ = false;
+    bool keyframe_initialized_ = false;
 
     double resolution_ = 0.05;
     int width_ = 500;
@@ -106,8 +131,19 @@ private:
     double min_update_translation_ = 0.01;
     double min_update_rotation_ = 0.01;
 
+    double keyframe_min_translation_ = 0.25;
+    double keyframe_min_rotation_ = 0.25;
+    std::size_t scan_signature_beam_step_ = 20;
+    int min_loop_closure_keyframe_age_ = 20;
+    double loop_closure_search_radius_ = 0.45;
+    double loop_closure_max_heading_diff_ = 0.70;
+    double loop_closure_max_signature_diff_ = 0.18;
+    int min_loop_closure_scan_gap_ = 20;
+
     int scans_integrated_ = 0;
     int stationary_scans_skipped_ = 0;
+    int loop_closure_count_ = 0;
+    int last_loop_closure_scan_ = -100000;
 };
 
 SimpleSlamNode::SimpleSlamNode()
@@ -127,13 +163,16 @@ SimpleSlamNode::SimpleSlamNode()
         this->create_publisher<geometry_msgs::msg::PoseStamped>("/estimated_pose", 10);
     scan_matched_pose_pub_ =
         this->create_publisher<geometry_msgs::msg::PoseStamped>("/scan_matched_pose", 10);
+    trajectory_pub_ = this->create_publisher<nav_msgs::msg::Path>("/trajectory", 10);
+    loop_closure_pose_pub_ =
+        this->create_publisher<geometry_msgs::msg::PoseStamped>("/loop_closure_pose", 10);
 
     tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
 
     RCLCPP_INFO(this->get_logger(), "Simple SLAM node started.");
     RCLCPP_INFO(
         this->get_logger(),
-        "Inputs: /odom, /scan. Outputs: /map, /estimated_pose, /scan_matched_pose, TF map->odom.");
+        "Inputs: /odom, /scan. Outputs: /map, /estimated_pose, /scan_matched_pose, /trajectory, /loop_closure_pose, TF map->odom.");
 }
 
 void SimpleSlamNode::initializeMap()
@@ -154,6 +193,8 @@ void SimpleSlamNode::initializeMap()
 
     likelihood_field_msg_ = map_msg_;
     likelihood_field_msg_.data.assign(width_ * height_, 0);
+
+    trajectory_msg_.header.frame_id = "map";
 }
 
 void SimpleSlamNode::odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
@@ -202,14 +243,21 @@ void SimpleSlamNode::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr m
     scan_received_ = true;
     scans_integrated_++;
     likelihood_field_dirty_ = true;
+    updateTrajectory(msg->header.stamp);
+    detectLoopClosure(*msg, msg->header.stamp);
+    if (shouldAddKeyFrame()) {
+        addKeyFrame(*msg);
+    }
 
     RCLCPP_INFO_THROTTLE(
         this->get_logger(),
         *this->get_clock(),
         5000,
-        "SLAM integrated=%d stationary_skipped=%d pose=(%.2f, %.2f, %.2f) match=%s score=%.3f occupied=%d",
+        "SLAM integrated=%d stationary_skipped=%d keyframes=%zu loops=%d pose=(%.2f, %.2f, %.2f) match=%s score=%.3f occupied=%d",
         scans_integrated_,
         stationary_scans_skipped_,
+        keyframes_.size(),
+        loop_closure_count_,
         slam_pose_.x,
         slam_pose_.y,
         slam_pose_.theta,
@@ -519,6 +567,160 @@ void SimpleSlamNode::publishMapToOdomTf(const rclcpp::Time & stamp)
     msg.child_frame_id = "odom";
     msg.transform = tf2::toMsg(map_to_odom);
     tf_broadcaster_->sendTransform(msg);
+}
+
+void SimpleSlamNode::updateTrajectory(const rclcpp::Time & stamp)
+{
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header.stamp = stamp;
+    pose.header.frame_id = "map";
+    pose.pose.position.x = slam_pose_.x;
+    pose.pose.position.y = slam_pose_.y;
+    pose.pose.orientation = yawToQuaternion(slam_pose_.theta);
+
+    trajectory_msg_.header.stamp = stamp;
+    trajectory_msg_.poses.push_back(pose);
+    trajectory_pub_->publish(trajectory_msg_);
+}
+
+void SimpleSlamNode::publishLoopClosurePose(const Pose2D & pose, const rclcpp::Time & stamp)
+{
+    geometry_msgs::msg::PoseStamped msg;
+    msg.header.stamp = stamp;
+    msg.header.frame_id = "map";
+    msg.pose.position.x = pose.x;
+    msg.pose.position.y = pose.y;
+    msg.pose.orientation = yawToQuaternion(pose.theta);
+    loop_closure_pose_pub_->publish(msg);
+}
+
+bool SimpleSlamNode::shouldAddKeyFrame() const
+{
+    if (!keyframe_initialized_) {
+        return true;
+    }
+
+    double distance = poseDistance(slam_pose_, last_keyframe_pose_);
+    double rotation = std::abs(normalizeAngle(slam_pose_.theta - last_keyframe_pose_.theta));
+
+    return distance >= keyframe_min_translation_ || rotation >= keyframe_min_rotation_;
+}
+
+void SimpleSlamNode::addKeyFrame(const sensor_msgs::msg::LaserScan & scan)
+{
+    KeyFrame keyframe;
+    keyframe.pose = slam_pose_;
+    keyframe.scan_signature = makeScanSignature(scan);
+    keyframe.scan_index = scans_integrated_;
+
+    keyframes_.push_back(keyframe);
+    last_keyframe_pose_ = slam_pose_;
+    keyframe_initialized_ = true;
+}
+
+bool SimpleSlamNode::detectLoopClosure(
+    const sensor_msgs::msg::LaserScan & scan, const rclcpp::Time & stamp)
+{
+    if (keyframes_.size() <= static_cast<std::size_t>(min_loop_closure_keyframe_age_)) {
+        return false;
+    }
+
+    if (scans_integrated_ - last_loop_closure_scan_ < min_loop_closure_scan_gap_) {
+        return false;
+    }
+
+    std::vector<float> current_signature = makeScanSignature(scan);
+    double best_difference = std::numeric_limits<double>::max();
+    std::size_t best_index = 0;
+    bool found_candidate = false;
+
+    for (std::size_t i = 0; i < keyframes_.size(); ++i) {
+        const KeyFrame & keyframe = keyframes_[i];
+        int keyframe_age = scans_integrated_ - keyframe.scan_index;
+        if (keyframe_age < min_loop_closure_keyframe_age_) {
+            continue;
+        }
+
+        double distance = poseDistance(slam_pose_, keyframe.pose);
+        if (distance > loop_closure_search_radius_) {
+            continue;
+        }
+
+        double heading_difference = std::abs(normalizeAngle(slam_pose_.theta - keyframe.pose.theta));
+        if (heading_difference > loop_closure_max_heading_diff_) {
+            continue;
+        }
+
+        double signature_difference =
+            scanSignatureDifference(current_signature, keyframe.scan_signature);
+        if (signature_difference < best_difference) {
+            best_difference = signature_difference;
+            best_index = i;
+            found_candidate = true;
+        }
+    }
+
+    if (!found_candidate || best_difference > loop_closure_max_signature_diff_) {
+        return false;
+    }
+
+    loop_closure_count_++;
+    last_loop_closure_scan_ = scans_integrated_;
+    const KeyFrame & matched_keyframe = keyframes_[best_index];
+    publishLoopClosurePose(matched_keyframe.pose, stamp);
+
+    RCLCPP_INFO(
+        this->get_logger(),
+        "Loop closure detected: current_scan=%d matched_keyframe=%zu old_scan=%d signature_diff=%.3f",
+        scans_integrated_,
+        best_index,
+        matched_keyframe.scan_index,
+        best_difference);
+
+    return true;
+}
+
+std::vector<float> SimpleSlamNode::makeScanSignature(
+    const sensor_msgs::msg::LaserScan & scan) const
+{
+    std::vector<float> signature;
+    signature.reserve(scan.ranges.size() / scan_signature_beam_step_ + 1);
+
+    for (std::size_t i = 0; i < scan.ranges.size(); i += scan_signature_beam_step_) {
+        float range = scan.ranges[i];
+        if (!std::isfinite(range) || range < scan.range_min) {
+            range = scan.range_max;
+        }
+
+        range = std::min(range, scan.range_max);
+        signature.push_back(range / scan.range_max);
+    }
+
+    return signature;
+}
+
+double SimpleSlamNode::scanSignatureDifference(
+    const std::vector<float> & first,
+    const std::vector<float> & second) const
+{
+    std::size_t count = std::min(first.size(), second.size());
+    if (count == 0) {
+        return std::numeric_limits<double>::max();
+    }
+
+    double difference_sum = 0.0;
+    for (std::size_t i = 0; i < count; ++i) {
+        difference_sum += std::abs(first[i] - second[i]);
+    }
+
+    return difference_sum / count;
+}
+
+double SimpleSlamNode::poseDistance(const Pose2D & first, const Pose2D & second) const
+{
+    double dx = first.x - second.x;
+    double dy = first.y - second.y;
+    return std::sqrt(dx * dx + dy * dy);
 }
 
 Pose2D SimpleSlamNode::odomMsgToPose(const nav_msgs::msg::Odometry & msg) const

--- a/src/slam/src/simple_slam_node.cpp
+++ b/src/slam/src/simple_slam_node.cpp
@@ -68,6 +68,7 @@ private:
     bool shouldAddKeyFrame() const;
     void addKeyFrame(const sensor_msgs::msg::LaserScan & scan);
     bool detectLoopClosure(const rclcpp::Time & stamp);
+    bool shouldApplyLoopClosureCorrection(std::size_t old_index, std::size_t current_index) const;
     void applyLoopClosureCorrection(std::size_t old_index, std::size_t current_index);
     std::vector<float> makeScanSignature(const sensor_msgs::msg::LaserScan & scan) const;
     double scanSignatureDifference(
@@ -144,11 +145,18 @@ private:
     double loop_closure_max_heading_diff_ = 0.70;
     double loop_closure_max_signature_diff_ = 0.18;
     int min_loop_closure_scan_gap_ = 20;
+    int min_correction_scan_gap_ = 80;
+    std::size_t min_correction_keyframe_gap_ = 12;
+    std::size_t min_old_keyframe_separation_for_correction_ = 8;
+    double loop_closure_correction_strength_ = 0.35;
 
     int scans_integrated_ = 0;
     int stationary_scans_skipped_ = 0;
     int loop_closure_count_ = 0;
+    int loop_closure_correction_count_ = 0;
     int last_loop_closure_scan_ = -100000;
+    int last_correction_scan_ = -100000;
+    std::size_t last_corrected_old_keyframe_ = std::numeric_limits<std::size_t>::max();
 };
 
 SimpleSlamNode::SimpleSlamNode()
@@ -262,11 +270,12 @@ void SimpleSlamNode::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr m
         this->get_logger(),
         *this->get_clock(),
         5000,
-        "SLAM integrated=%d stationary_skipped=%d keyframes=%zu loops=%d pose=(%.2f, %.2f, %.2f) match=%s score=%.3f occupied=%d",
+        "SLAM integrated=%d stationary_skipped=%d keyframes=%zu loops=%d corrections=%d pose=(%.2f, %.2f, %.2f) match=%s score=%.3f occupied=%d",
         scans_integrated_,
         stationary_scans_skipped_,
         keyframes_.size(),
         loop_closure_count_,
+        loop_closure_correction_count_,
         slam_pose_.x,
         slam_pose_.y,
         slam_pose_.theta,
@@ -698,17 +707,52 @@ bool SimpleSlamNode::detectLoopClosure(const rclcpp::Time & stamp)
     last_loop_closure_scan_ = scans_integrated_;
     const KeyFrame & matched_keyframe = keyframes_[best_index];
     publishLoopClosurePose(matched_keyframe.pose, stamp);
-    applyLoopClosureCorrection(best_index, current_index);
-    publishCorrectedTrajectory(stamp);
+
+    bool correction_applied = false;
+    if (shouldApplyLoopClosureCorrection(best_index, current_index)) {
+        applyLoopClosureCorrection(best_index, current_index);
+        publishCorrectedTrajectory(stamp);
+        correction_applied = true;
+    }
 
     RCLCPP_INFO(
         this->get_logger(),
-        "Loop closure detected: current_scan=%d current_keyframe=%zu matched_keyframe=%zu old_scan=%d signature_diff=%.3f",
+        "Loop closure detected: current_scan=%d current_keyframe=%zu matched_keyframe=%zu old_scan=%d signature_diff=%.3f correction=%s",
         scans_integrated_,
         current_index,
         best_index,
         matched_keyframe.scan_index,
-        best_difference);
+        best_difference,
+        correction_applied ? "applied" : "skipped");
+
+    return true;
+}
+
+bool SimpleSlamNode::shouldApplyLoopClosureCorrection(
+    std::size_t old_index, std::size_t current_index) const
+{
+    if (current_index <= old_index) {
+        return false;
+    }
+
+    if (current_index - old_index < min_correction_keyframe_gap_) {
+        return false;
+    }
+
+    if (scans_integrated_ - last_correction_scan_ < min_correction_scan_gap_) {
+        return false;
+    }
+
+    if (last_corrected_old_keyframe_ != std::numeric_limits<std::size_t>::max()) {
+        std::size_t separation =
+            old_index > last_corrected_old_keyframe_ ?
+            old_index - last_corrected_old_keyframe_ :
+            last_corrected_old_keyframe_ - old_index;
+
+        if (separation < min_old_keyframe_separation_for_correction_) {
+            return false;
+        }
+    }
 
     return true;
 }
@@ -723,9 +767,10 @@ void SimpleSlamNode::applyLoopClosureCorrection(
     const Pose2D old_pose = keyframes_[old_index].corrected_pose;
     const Pose2D current_pose = keyframes_[current_index].corrected_pose;
 
-    double error_x = old_pose.x - current_pose.x;
-    double error_y = old_pose.y - current_pose.y;
-    double error_theta = normalizeAngle(old_pose.theta - current_pose.theta);
+    double error_x = loop_closure_correction_strength_ * (old_pose.x - current_pose.x);
+    double error_y = loop_closure_correction_strength_ * (old_pose.y - current_pose.y);
+    double error_theta =
+        loop_closure_correction_strength_ * normalizeAngle(old_pose.theta - current_pose.theta);
     double span = static_cast<double>(current_index - old_index);
 
     for (std::size_t i = old_index + 1; i <= current_index; ++i) {
@@ -735,6 +780,10 @@ void SimpleSlamNode::applyLoopClosureCorrection(
         keyframes_[i].corrected_pose.theta =
             normalizeAngle(keyframes_[i].corrected_pose.theta + fraction * error_theta);
     }
+
+    loop_closure_correction_count_++;
+    last_correction_scan_ = scans_integrated_;
+    last_corrected_old_keyframe_ = old_index;
 }
 
 std::vector<float> SimpleSlamNode::makeScanSignature(


### PR DESCRIPTION
## Summary

This PR adds the first learning version of the `slam` package.

The package now includes:

- live occupancy-grid mapping from `/odom` and `/scan`
- local scan matching for small pose correction
- `/estimated_pose` and `map -> odom`
- trajectory history publishing
- keyframe storage
- loop-closure detection from keyframe scan similarity
- simple loop-closure trajectory correction
- `/corrected_map` rebuilt from corrected keyframes
- updated package and root README documentation

## Notes

This is intended to close the first version of the SLAM package as a learning milestone.

Known limits remain, including:

- no real pose graph optimization yet
- no full global relocalization
- wall-hit / odometry-disagreement handling is still incomplete

Tracked follow-up issue:
- #25 SLAM v1 does not detect wall-hit / odometry-disagreement cases reliably

## Validation

```bash
colcon build --symlink-install
```