### PR TITLE
Add path following controller and planner improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Current behavior:
 - rotate in place first when the heading error is large
 - slow down near the goal position
 - rotate in place at the end to match the final goal orientation
+- report continuous path progress and goal distance while following the path
+- warn when commanded motion is not producing enough movement or goal improvement
 - publish `/cmd_vel` for the simulation robot
 
 This package is meant to keep planning and control separate.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The long term goal is to learn:
 - mapping: finished
 - localization : finished
 - SLAM : first version finished
-- planning : A* planner with collision clearance finished
+- planning : A* planner with collision clearance and smoothing finished
 - path follow / control : pure pursuit first version finished
 - navigation : in planning
 
@@ -144,13 +144,14 @@ Simple logic:
 - inflate obstacles using a conservative circular robot radius from the simulation geometry
 - convert start and goal from world coordinates into map grid cells
 - run A* on an inflated 8-connected occupancy grid
+- smooth the raw A* path using line-of-sight shortcutting on the inflated map
 - keep the final path pose orientation from the RViz goal pose
 - publish the planned path back in the `map` frame
 
 This first planner uses the static saved map from `nav2_map_server`.
 It treats unknown cells as blocked and publishes the inflated map for RViz checking.
 It only plans a global path.
-It does not yet include path smoothing, local planning, or path following.
+It does not yet include local planning.
 
 ### `path_follow_control`
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The long term goal is to learn:
 - localization : finished
 - SLAM : first version finished
 - planning : A* planner with collision clearance finished
-- path follow / control : package created, implementation next
+- path follow / control : pure pursuit first version finished
 - navigation : in planning
 
 ## Packages
@@ -144,6 +144,7 @@ Simple logic:
 - inflate obstacles using a conservative circular robot radius from the simulation geometry
 - convert start and goal from world coordinates into map grid cells
 - run A* on an inflated 8-connected occupancy grid
+- keep the final path pose orientation from the RViz goal pose
 - publish the planned path back in the `map` frame
 
 This first planner uses the static saved map from `nav2_map_server`.
@@ -170,9 +171,17 @@ Simple role:
 - compare the current robot pose against that path
 - compute velocity commands that move the robot along the path
 
+Current behavior:
+
+- follow `/planned_path` with a pure-pursuit style controller
+- rotate in place first when the heading error is large
+- slow down near the goal position
+- rotate in place at the end to match the final goal orientation
+- publish `/cmd_vel` for the simulation robot
+
 This package is meant to keep planning and control separate.
 `motion_planning` chooses where to go.
-`path_follow_control` will decide how to move right now.
+`path_follow_control` decides how to move right now.
 It is the right place for path tracking first, and local planning later if needed.
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The long term goal is to learn:
 - localization : finished
 - SLAM : first version finished
 - planning : A* planner with collision clearance finished
+- path follow / control : package created, implementation next
 - navigation : in planning
 
 ## Packages
@@ -149,6 +150,30 @@ This first planner uses the static saved map from `nav2_map_server`.
 It treats unknown cells as blocked and publishes the inflated map for RViz checking.
 It only plans a global path.
 It does not yet include path smoothing, local planning, or path following.
+
+### `path_follow_control`
+
+This package is the next learning layer after global path planning.
+
+It will read:
+
+- `/planned_path`
+- `/estimated_pose`
+
+It will publish:
+
+- `/cmd_vel`
+
+Simple role:
+
+- take the global path from `motion_planning`
+- compare the current robot pose against that path
+- compute velocity commands that move the robot along the path
+
+This package is meant to keep planning and control separate.
+`motion_planning` chooses where to go.
+`path_follow_control` will decide how to move right now.
+It is the right place for path tracking first, and local planning later if needed.
 ## Quick Start
 
 ### Prerequisites

--- a/src/motion_planning/README.md
+++ b/src/motion_planning/README.md
@@ -22,6 +22,7 @@ Current behavior:
 - uses the RViz goal pose as the target
 - inflates obstacles using a conservative circular robot radius of `0.35 m`
 - runs A* on an inflated 8-connected grid
+- preserves the RViz goal orientation on the final path pose
 - treats unknown cells as blocked
 
 How to test:

--- a/src/motion_planning/README.md
+++ b/src/motion_planning/README.md
@@ -22,6 +22,7 @@ Current behavior:
 - uses the RViz goal pose as the target
 - inflates obstacles using a conservative circular robot radius of `0.35 m`
 - runs A* on an inflated 8-connected grid
+- smooths the raw A* path using line-of-sight shortcutting on `inflated_map`
 - preserves the RViz goal orientation on the final path pose
 - treats unknown cells as blocked
 

--- a/src/motion_planning/src/motion_planning_node.cpp
+++ b/src/motion_planning/src/motion_planning_node.cpp
@@ -292,9 +292,13 @@ private:
       gridToWorld(x, y, pose.pose.position.x, pose.pose.position.y);
       pose.pose.position.z = 0.0;
 
-      const double yaw = computePoseYaw(path_indices, i);
-      pose.pose.orientation.z = std::sin(yaw * 0.5);
-      pose.pose.orientation.w = std::cos(yaw * 0.5);
+      if (i == path_indices.size() - 1) {
+        pose.pose.orientation = goal_pose_.pose.orientation;
+      } else {
+        const double yaw = computePoseYaw(path_indices, i);
+        pose.pose.orientation.z = std::sin(yaw * 0.5);
+        pose.pose.orientation.w = std::cos(yaw * 0.5);
+      }
       path_msg.poses.push_back(pose);
     }
 

--- a/src/motion_planning/src/motion_planning_node.cpp
+++ b/src/motion_planning/src/motion_planning_node.cpp
@@ -182,11 +182,12 @@ private:
       return false;
     }
 
-    publishPath(path_indices);
+    const std::vector<int> smoothed_path_indices = smoothPath(path_indices);
+    publishPath(smoothed_path_indices);
     RCLCPP_INFO(
       this->get_logger(),
-      "Published path with %zu poses from (%d, %d) to (%d, %d).",
-      path_indices.size(), start_x, start_y, goal_x, goal_y);
+      "Published smoothed path with %zu poses (raw A* path had %zu poses) from (%d, %d) to (%d, %d).",
+      smoothed_path_indices.size(), path_indices.size(), start_x, start_y, goal_x, goal_y);
     return true;
   }
 
@@ -273,6 +274,91 @@ private:
 
     std::reverse(path.begin(), path.end());
     return path;
+  }
+
+  std::vector<int> smoothPath(const std::vector<int> & raw_path_indices) const
+  {
+    if (raw_path_indices.size() <= 2) {
+      return raw_path_indices;
+    }
+
+    std::vector<int> smoothed_path;
+    smoothed_path.reserve(raw_path_indices.size());
+    smoothed_path.push_back(raw_path_indices.front());
+
+    std::size_t anchor_index = 0;
+    while (anchor_index < raw_path_indices.size() - 1) {
+      std::size_t furthest_visible_index = anchor_index + 1;
+
+      for (std::size_t candidate_index = anchor_index + 1;
+        candidate_index < raw_path_indices.size();
+        ++candidate_index)
+      {
+        if (!hasLineOfSight(raw_path_indices[anchor_index], raw_path_indices[candidate_index])) {
+          break;
+        }
+        furthest_visible_index = candidate_index;
+      }
+
+      smoothed_path.push_back(raw_path_indices[furthest_visible_index]);
+      anchor_index = furthest_visible_index;
+    }
+
+    return smoothed_path;
+  }
+
+  bool hasLineOfSight(int start_index, int end_index) const
+  {
+    const int width = static_cast<int>(inflated_map_.info.width);
+
+    const int start_x = start_index % width;
+    const int start_y = start_index / width;
+    const int end_x = end_index % width;
+    const int end_y = end_index / width;
+
+    const auto cells_on_line = bresenhamLine(start_x, start_y, end_x, end_y);
+    for (const auto & cell : cells_on_line) {
+      if (!isValidCell(cell.first, cell.second) ||
+        !isCellFreeForPlanning(cell.first, cell.second))
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  std::vector<std::pair<int, int>> bresenhamLine(int x0, int y0, int x1, int y1) const
+  {
+    std::vector<std::pair<int, int>> cells;
+
+    int dx = std::abs(x1 - x0);
+    int dy = std::abs(y1 - y0);
+    int sx = (x0 < x1) ? 1 : -1;
+    int sy = (y0 < y1) ? 1 : -1;
+    int err = dx - dy;
+
+    int current_x = x0;
+    int current_y = y0;
+
+    while (true) {
+      cells.emplace_back(current_x, current_y);
+      if (current_x == x1 && current_y == y1) {
+        break;
+      }
+
+      const int twice_err = 2 * err;
+      if (twice_err > -dy) {
+        err -= dy;
+        current_x += sx;
+      }
+      if (twice_err < dx) {
+        err += dx;
+        current_y += sy;
+      }
+    }
+
+    return cells;
   }
 
   void publishPath(const std::vector<int> & path_indices)

--- a/src/path_follow_control/CMakeLists.txt
+++ b/src/path_follow_control/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.8)
+project(path_follow_control)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+add_executable(path_follow_control_node
+  src/path_follow_control_node.cpp
+)
+
+ament_target_dependencies(path_follow_control_node
+  rclcpp
+  nav_msgs
+  geometry_msgs
+)
+
+install(TARGETS
+  path_follow_control_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/path_follow_control/README.md
+++ b/src/path_follow_control/README.md
@@ -29,6 +29,8 @@ Current behavior:
 - slow down near the goal
 - stop when the goal position is reached
 - rotate in place to align with the final goal orientation
+- report continuous path progress and goal distance in the logs
+- declare stuck when the robot is commanded to move but does not move enough or reduce goal distance enough over time
 
 How to test:
 

--- a/src/path_follow_control/README.md
+++ b/src/path_follow_control/README.md
@@ -1,0 +1,34 @@
+# Path Follow Control Package
+
+This package is the next learning step after `motion_planning`.
+
+Its role is different from the global planner:
+
+- `motion_planning` decides which path the robot should take
+- `path_follow_control` decides what velocity command the robot should send right now
+
+Planned inputs:
+
+- `/planned_path`
+- `/estimated_pose`
+
+Planned output:
+
+- `/cmd_vel`
+
+The first version should focus on path following for a static path.
+
+Main goal:
+
+- convert a planned path into smooth robot motion
+
+Likely learning steps:
+
+- rotate toward the path direction
+- drive toward the next path point
+- slow down near the goal
+- stop when the goal is reached
+
+This package is not the global planner.
+It is also not yet a full local planner with dynamic obstacle avoidance.
+Its role is the control layer between path planning and actual robot motion.

--- a/src/path_follow_control/README.md
+++ b/src/path_follow_control/README.md
@@ -7,27 +7,39 @@ Its role is different from the global planner:
 - `motion_planning` decides which path the robot should take
 - `path_follow_control` decides what velocity command the robot should send right now
 
-Planned inputs:
+Inputs:
 
 - `/planned_path`
 - `/estimated_pose`
 
-Planned output:
+Output:
 
 - `/cmd_vel`
 
-The first version should focus on path following for a static path.
+The first version uses pure pursuit for path following on a static planned path.
 
 Main goal:
 
 - convert a planned path into smooth robot motion
 
-Likely learning steps:
+Current behavior:
 
 - rotate toward the path direction
-- drive toward the next path point
+- follow a lookahead point along the path
 - slow down near the goal
-- stop when the goal is reached
+- stop when the goal position is reached
+- rotate in place to align with the final goal orientation
+
+How to test:
+
+- start simulation
+- start the static map server with `src/mapping/maps/maze_map.yaml`
+- start `kalman_localization_node`
+- start `motion_planning_node`
+- start `path_follow_control_node`
+- open RViz with fixed frame `map`
+- add `/map`, `/inflated_map`, and `/planned_path`
+- click a goal with the `2D Goal Pose` tool, including a desired final heading
 
 This package is not the global planner.
 It is also not yet a full local planner with dynamic obstacle avoidance.

--- a/src/path_follow_control/package.xml
+++ b/src/path_follow_control/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>path_follow_control</name>
+  <version>0.0.0</version>
+  <description>Learning package for path following and motion control in ROS 2.</description>
+  <maintainer email="tj19970215@gmail.com">jtao</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>nav_msgs</depend>
+  <depend>geometry_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/path_follow_control/src/path_follow_control_node.cpp
+++ b/src/path_follow_control/src/path_follow_control_node.cpp
@@ -1,4 +1,12 @@
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "nav_msgs/msg/path.hpp"
 #include "rclcpp/rclcpp.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
 
 class PathFollowControlNode : public rclcpp::Node
 {
@@ -6,10 +14,249 @@ public:
   PathFollowControlNode()
   : Node("path_follow_control_node")
   {
+    path_sub_ = this->create_subscription<nav_msgs::msg::Path>(
+      "/planned_path", 10,
+      std::bind(&PathFollowControlNode::pathCallback, this, std::placeholders::_1));
+
+    pose_sub_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
+      "/estimated_pose", 10,
+      std::bind(&PathFollowControlNode::poseCallback, this, std::placeholders::_1));
+
+    cmd_vel_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", 10);
+
+    control_timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(100),
+      std::bind(&PathFollowControlNode::controlLoop, this));
+
     RCLCPP_INFO(
       this->get_logger(),
-      "Path follow control package initialized. Controller implementation will be added next.");
+      "PathFollowControlNode started. Inputs: /planned_path, /estimated_pose. Output: /cmd_vel.");
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Pure pursuit enabled with lookahead %.2f m and rotate-in-place threshold %.2f rad.",
+      lookahead_distance_,
+      rotate_in_place_angle_threshold_);
   }
+
+private:
+  void pathCallback(const nav_msgs::msg::Path::SharedPtr msg)
+  {
+    path_ = *msg;
+    has_path_ = !path_.poses.empty();
+
+    if (!has_path_) {
+      publishStop();
+      RCLCPP_WARN(this->get_logger(), "Received empty path. Stopping robot.");
+      return;
+    }
+
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Received path with %zu poses.",
+      path_.poses.size());
+  }
+
+  void poseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg)
+  {
+    current_pose_ = *msg;
+    has_pose_ = true;
+  }
+
+  void controlLoop()
+  {
+    if (!has_path_ || !has_pose_) {
+      publishStop();
+      return;
+    }
+
+    if (path_.header.frame_id != "map" || current_pose_.header.frame_id != "map") {
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 2000,
+        "Controller expects path and pose in map frame.");
+      publishStop();
+      return;
+    }
+
+    const geometry_msgs::msg::PoseStamped & goal_pose = path_.poses.back();
+    const double goal_distance = distanceBetween(current_pose_, goal_pose);
+    const double goal_heading_error =
+      normalizeAngle(getYaw(goal_pose) - getYaw(current_pose_));
+
+    if (goal_distance < goal_tolerance_distance_) {
+      if (std::abs(goal_heading_error) < goal_tolerance_angle_) {
+        publishStop();
+        has_path_ = false;
+        path_.poses.clear();
+        RCLCPP_INFO_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Goal position and final orientation reached. Robot stopped.");
+        return;
+      }
+
+      geometry_msgs::msg::Twist cmd_vel;
+      cmd_vel.linear.x = 0.0;
+      cmd_vel.angular.z = computeFinalAlignmentAngularSpeed(goal_heading_error);
+      cmd_vel_pub_->publish(cmd_vel);
+      RCLCPP_INFO_THROTTLE(
+        this->get_logger(), *this->get_clock(), 2000,
+        "Goal position reached. Rotating to final goal orientation.");
+      return;
+    }
+
+    const std::size_t closest_index = findClosestPathIndex();
+    const std::size_t target_index = findLookaheadIndex(closest_index);
+    const geometry_msgs::msg::PoseStamped & target_pose = path_.poses[target_index];
+
+    const double robot_x = current_pose_.pose.position.x;
+    const double robot_y = current_pose_.pose.position.y;
+    const double robot_yaw = getYaw(current_pose_);
+    const double target_x = target_pose.pose.position.x;
+    const double target_y = target_pose.pose.position.y;
+
+    const double dx = target_x - robot_x;
+    const double dy = target_y - robot_y;
+    const double target_distance = std::sqrt(dx * dx + dy * dy);
+    const double target_bearing = std::atan2(dy, dx);
+    const double heading_error = normalizeAngle(target_bearing - robot_yaw);
+
+    geometry_msgs::msg::Twist cmd_vel;
+
+    if (std::abs(heading_error) > rotate_in_place_angle_threshold_) {
+      cmd_vel.linear.x = 0.0;
+      cmd_vel.angular.z = clamp(
+        rotate_in_place_gain_ * heading_error,
+        -max_angular_speed_,
+        max_angular_speed_);
+    } else {
+      const double curvature = (target_distance > 1e-6) ?
+        2.0 * std::sin(heading_error) / target_distance : 0.0;
+
+      const double distance_scale = std::min(target_distance / lookahead_distance_, 1.0);
+      const double angle_scale = std::max(
+        0.0,
+        1.0 - std::abs(heading_error) / rotate_in_place_angle_threshold_);
+
+      cmd_vel.linear.x = max_linear_speed_ * distance_scale * angle_scale;
+      cmd_vel.angular.z = clamp(
+        cmd_vel.linear.x * curvature,
+        -max_angular_speed_,
+        max_angular_speed_);
+
+      if (goal_distance < slow_down_goal_distance_) {
+        cmd_vel.linear.x *= goal_distance / slow_down_goal_distance_;
+      }
+    }
+
+    cmd_vel_pub_->publish(cmd_vel);
+  }
+
+  std::size_t findClosestPathIndex() const
+  {
+    std::size_t best_index = 0;
+    double best_distance = std::numeric_limits<double>::infinity();
+
+    for (std::size_t i = 0; i < path_.poses.size(); ++i) {
+      const double distance = distanceBetween(current_pose_, path_.poses[i]);
+      if (distance < best_distance) {
+        best_distance = distance;
+        best_index = i;
+      }
+    }
+
+    return best_index;
+  }
+
+  std::size_t findLookaheadIndex(std::size_t closest_index) const
+  {
+    double accumulated_distance = 0.0;
+
+    for (std::size_t i = closest_index; i + 1 < path_.poses.size(); ++i) {
+      accumulated_distance += distanceBetween(path_.poses[i], path_.poses[i + 1]);
+      if (accumulated_distance >= lookahead_distance_) {
+        return i + 1;
+      }
+    }
+
+    return path_.poses.size() - 1;
+  }
+
+  double distanceBetween(
+    const geometry_msgs::msg::PoseStamped & first,
+    const geometry_msgs::msg::PoseStamped & second) const
+  {
+    const double dx = second.pose.position.x - first.pose.position.x;
+    const double dy = second.pose.position.y - first.pose.position.y;
+    return std::sqrt(dx * dx + dy * dy);
+  }
+
+  double getYaw(const geometry_msgs::msg::PoseStamped & pose) const
+  {
+    const auto & q = pose.pose.orientation;
+    const double siny_cosp = 2.0 * (q.w * q.z + q.x * q.y);
+    const double cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z);
+    return std::atan2(siny_cosp, cosy_cosp);
+  }
+
+  double normalizeAngle(double angle) const
+  {
+    while (angle > M_PI) {
+      angle -= 2.0 * M_PI;
+    }
+    while (angle < -M_PI) {
+      angle += 2.0 * M_PI;
+    }
+    return angle;
+  }
+
+  double clamp(double value, double low, double high) const
+  {
+    return std::max(low, std::min(value, high));
+  }
+
+  double computeFinalAlignmentAngularSpeed(double heading_error) const
+  {
+    const double commanded_speed = clamp(
+      final_alignment_gain_ * heading_error,
+      -final_alignment_max_angular_speed_,
+      final_alignment_max_angular_speed_);
+
+    if (std::abs(commanded_speed) < final_alignment_min_angular_speed_) {
+      return (heading_error >= 0.0) ?
+        final_alignment_min_angular_speed_ :
+        -final_alignment_min_angular_speed_;
+    }
+
+    return commanded_speed;
+  }
+
+  void publishStop()
+  {
+    geometry_msgs::msg::Twist stop_cmd;
+    cmd_vel_pub_->publish(stop_cmd);
+  }
+
+  nav_msgs::msg::Path path_;
+  geometry_msgs::msg::PoseStamped current_pose_;
+
+  rclcpp::Subscription<nav_msgs::msg::Path>::SharedPtr path_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr pose_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_pub_;
+  rclcpp::TimerBase::SharedPtr control_timer_;
+
+  bool has_path_ = false;
+  bool has_pose_ = false;
+
+  double lookahead_distance_ = 0.35;
+  double max_linear_speed_ = 0.20;
+  double max_angular_speed_ = 0.80;
+  double rotate_in_place_angle_threshold_ = 0.50;
+  double rotate_in_place_gain_ = 1.50;
+  double goal_tolerance_distance_ = 0.10;
+  double goal_tolerance_angle_ = 0.15;
+  double slow_down_goal_distance_ = 0.50;
+  double final_alignment_gain_ = 1.50;
+  double final_alignment_min_angular_speed_ = 0.20;
+  double final_alignment_max_angular_speed_ = 0.50;
 };
 
 int main(int argc, char ** argv)

--- a/src/path_follow_control/src/path_follow_control_node.cpp
+++ b/src/path_follow_control/src/path_follow_control_node.cpp
@@ -1,0 +1,21 @@
+#include "rclcpp/rclcpp.hpp"
+
+class PathFollowControlNode : public rclcpp::Node
+{
+public:
+  PathFollowControlNode()
+  : Node("path_follow_control_node")
+  {
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Path follow control package initialized. Controller implementation will be added next.");
+  }
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<PathFollowControlNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/path_follow_control/src/path_follow_control_node.cpp
+++ b/src/path_follow_control/src/path_follow_control_node.cpp
@@ -4,6 +4,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <limits>
 #include <vector>
@@ -46,10 +47,12 @@ private:
 
     if (!has_path_) {
       publishStop();
+      resetProgressMonitor();
       RCLCPP_WARN(this->get_logger(), "Received empty path. Stopping robot.");
       return;
     }
 
+    resetProgressMonitor();
     RCLCPP_INFO(
       this->get_logger(),
       "Received path with %zu poses.",
@@ -66,6 +69,7 @@ private:
   {
     if (!has_path_ || !has_pose_) {
       publishStop();
+      resetProgressMonitor();
       return;
     }
 
@@ -74,6 +78,7 @@ private:
         this->get_logger(), *this->get_clock(), 2000,
         "Controller expects path and pose in map frame.");
       publishStop();
+      resetProgressMonitor();
       return;
     }
 
@@ -87,6 +92,7 @@ private:
         publishStop();
         has_path_ = false;
         path_.poses.clear();
+        resetProgressMonitor();
         RCLCPP_INFO_THROTTLE(
           this->get_logger(), *this->get_clock(), 2000,
           "Goal position and final orientation reached. Robot stopped.");
@@ -97,6 +103,7 @@ private:
       cmd_vel.linear.x = 0.0;
       cmd_vel.angular.z = computeFinalAlignmentAngularSpeed(goal_heading_error);
       cmd_vel_pub_->publish(cmd_vel);
+      resetProgressMonitor();
       RCLCPP_INFO_THROTTLE(
         this->get_logger(), *this->get_clock(), 2000,
         "Goal position reached. Rotating to final goal orientation.");
@@ -148,6 +155,7 @@ private:
     }
 
     cmd_vel_pub_->publish(cmd_vel);
+    updateProgressMonitor(goal_distance, cmd_vel);
   }
 
   std::size_t findClosestPathIndex() const
@@ -235,6 +243,143 @@ private:
     cmd_vel_pub_->publish(stop_cmd);
   }
 
+  void resetProgressMonitor()
+  {
+    progress_monitor_initialized_ = false;
+    is_stuck_ = false;
+  }
+
+  double computePathProgressDistance() const
+  {
+    if (path_.poses.empty()) {
+      return 0.0;
+    }
+
+    if (path_.poses.size() == 1) {
+      return 0.0;
+    }
+
+    const double robot_x = current_pose_.pose.position.x;
+    const double robot_y = current_pose_.pose.position.y;
+
+    double accumulated_distance = 0.0;
+    double best_progress_distance = 0.0;
+    double best_distance_to_path = std::numeric_limits<double>::infinity();
+
+    for (std::size_t i = 0; i + 1 < path_.poses.size(); ++i) {
+      const double x0 = path_.poses[i].pose.position.x;
+      const double y0 = path_.poses[i].pose.position.y;
+      const double x1 = path_.poses[i + 1].pose.position.x;
+      const double y1 = path_.poses[i + 1].pose.position.y;
+
+      const double dx = x1 - x0;
+      const double dy = y1 - y0;
+      const double segment_length_squared = dx * dx + dy * dy;
+      const double segment_length = std::sqrt(segment_length_squared);
+
+      if (segment_length < 1e-6) {
+        continue;
+      }
+
+      const double projection_numerator =
+        (robot_x - x0) * dx + (robot_y - y0) * dy;
+      const double t = clamp(projection_numerator / segment_length_squared, 0.0, 1.0);
+
+      const double projected_x = x0 + t * dx;
+      const double projected_y = y0 + t * dy;
+      const double distance_to_segment =
+        std::sqrt(
+        (robot_x - projected_x) * (robot_x - projected_x) +
+        (robot_y - projected_y) * (robot_y - projected_y));
+
+      if (distance_to_segment < best_distance_to_path) {
+        best_distance_to_path = distance_to_segment;
+        best_progress_distance = accumulated_distance + t * segment_length;
+      }
+
+      accumulated_distance += segment_length;
+    }
+
+    return best_progress_distance;
+  }
+
+  double computeTotalPathLength() const
+  {
+    if (path_.poses.size() < 2) {
+      return 0.0;
+    }
+
+    double total_length = 0.0;
+    for (std::size_t i = 0; i + 1 < path_.poses.size(); ++i) {
+      total_length += distanceBetween(path_.poses[i], path_.poses[i + 1]);
+    }
+    return total_length;
+  }
+
+  void updateProgressMonitor(
+    double goal_distance,
+    const geometry_msgs::msg::Twist & cmd_vel)
+  {
+    const double progress_distance = computePathProgressDistance();
+    const double total_path_length = computeTotalPathLength();
+
+    if (!progress_monitor_initialized_) {
+      monitor_start_time_ = this->now();
+      monitor_start_pose_ = current_pose_;
+      monitor_start_goal_distance_ = goal_distance;
+      progress_monitor_initialized_ = true;
+      is_stuck_ = false;
+      return;
+    }
+
+    const double path_progress_ratio = (total_path_length > 1e-6) ?
+      progress_distance / total_path_length :
+      1.0;
+
+    RCLCPP_INFO_THROTTLE(
+      this->get_logger(), *this->get_clock(), 2000,
+      "Path progress %.0f%%, goal distance %.2f m.",
+      path_progress_ratio * 100.0,
+      goal_distance);
+
+    const bool commanding_motion =
+      std::abs(cmd_vel.linear.x) > min_commanded_linear_speed_ ||
+      std::abs(cmd_vel.angular.z) > min_commanded_angular_speed_;
+
+    if (!commanding_motion) {
+      monitor_start_time_ = this->now();
+      monitor_start_pose_ = current_pose_;
+      monitor_start_goal_distance_ = goal_distance;
+      is_stuck_ = false;
+      return;
+    }
+
+    const double elapsed_time = (this->now() - monitor_start_time_).seconds();
+    if (elapsed_time < stuck_detection_window_seconds_) {
+      return;
+    }
+
+    const double moved_distance = distanceBetween(current_pose_, monitor_start_pose_);
+    const double goal_distance_improvement = monitor_start_goal_distance_ - goal_distance;
+
+    is_stuck_ =
+      moved_distance < min_progress_distance_m_ &&
+      goal_distance_improvement < min_goal_distance_improvement_m_;
+
+    if (is_stuck_) {
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 2000,
+        "Stuck detected: moved %.3f m, goal improved %.3f m over %.1f s.",
+        moved_distance,
+        goal_distance_improvement,
+        elapsed_time);
+    }
+
+    monitor_start_time_ = this->now();
+    monitor_start_pose_ = current_pose_;
+    monitor_start_goal_distance_ = goal_distance;
+  }
+
   nav_msgs::msg::Path path_;
   geometry_msgs::msg::PoseStamped current_pose_;
 
@@ -245,6 +390,12 @@ private:
 
   bool has_path_ = false;
   bool has_pose_ = false;
+  bool progress_monitor_initialized_ = false;
+  bool is_stuck_ = false;
+
+  rclcpp::Time monitor_start_time_;
+  geometry_msgs::msg::PoseStamped monitor_start_pose_;
+  double monitor_start_goal_distance_ = 0.0;
 
   double lookahead_distance_ = 0.35;
   double max_linear_speed_ = 0.20;
@@ -257,6 +408,11 @@ private:
   double final_alignment_gain_ = 1.50;
   double final_alignment_min_angular_speed_ = 0.20;
   double final_alignment_max_angular_speed_ = 0.50;
+  double stuck_detection_window_seconds_ = 4.0;
+  double min_progress_distance_m_ = 0.05;
+  double min_goal_distance_improvement_m_ = 0.05;
+  double min_commanded_linear_speed_ = 0.02;
+  double min_commanded_angular_speed_ = 0.20;
 };
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Summary
- add the `path_follow_control` package and implement a pure-pursuit style path follower
- add final orientation alignment at the goal
- preserve the RViz goal orientation on the final planned path pose
- add obstacle-aware path smoothing in `motion_planning`
- add path progress monitoring and simple stuck detection logs in the controller
- update repository and package READMEs

## Validation
- `colcon build --packages-select motion_planning path_follow_control --symlink-install`
- tested in simulation with map server, Kalman localization, RViz goal pose, path following, final alignment, smoothing, and progress monitoring
