### PR TITLE
Clean up SLAM package organization

### DIFF
--- a/src/slam/CMakeLists.txt
+++ b/src/slam/CMakeLists.txt
@@ -23,7 +23,10 @@ if(BUILD_TESTING)
 endif()
 
 add_library(simple_slam_lib
+  src/loop_closure.cpp
   src/simple_slam.cpp
+  src/slam_localization.cpp
+  src/slam_mapper.cpp
 )
 
 target_include_directories(simple_slam_lib PUBLIC

--- a/src/slam/CMakeLists.txt
+++ b/src/slam/CMakeLists.txt
@@ -68,6 +68,7 @@ install(TARGETS
 )
 
 install(DIRECTORY
+  config
   launch
   DESTINATION share/${PROJECT_NAME}
 )

--- a/src/slam/CMakeLists.txt
+++ b/src/slam/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -21,8 +22,33 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+add_library(simple_slam_lib
+  src/simple_slam.cpp
+)
+
+target_include_directories(simple_slam_lib PUBLIC
+  include
+)
+
+ament_target_dependencies(simple_slam_lib
+  builtin_interfaces
+  geometry_msgs
+  sensor_msgs
+  nav_msgs
+  tf2
+  tf2_geometry_msgs
+)
+
 add_executable(simple_slam_node
   src/simple_slam_node.cpp
+)
+
+target_include_directories(simple_slam_node PUBLIC
+  include
+)
+
+target_link_libraries(simple_slam_node
+  simple_slam_lib
 )
 
 ament_target_dependencies(simple_slam_node
@@ -36,6 +62,7 @@ ament_target_dependencies(simple_slam_node
 )
 
 install(TARGETS
+  simple_slam_lib
   simple_slam_node
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/src/slam/README.md
+++ b/src/slam/README.md
@@ -85,6 +85,52 @@ scan matching can correct the guess
 the chosen pose updates the map
 ```
 
+## Code Organization
+
+The SLAM package is split into a small ROS wrapper plus algorithm files.
+
+The ROS wrapper is:
+
+```text
+src/slam/src/simple_slam_node.cpp
+```
+
+It owns ROS 2 subscriptions, publishers, TF broadcasting, parameter loading, and logging.
+It should not contain the SLAM algorithm itself.
+
+The main algorithm coordinator is:
+
+```text
+src/slam/include/slam/simple_slam.hpp
+src/slam/src/simple_slam.cpp
+```
+
+`SimpleSlam` keeps the full SLAM flow readable:
+
+```text
+odometry prediction
+localization correction
+map update
+keyframe and loop-closure update
+```
+
+The three learning parts are:
+
+- `SlamMapper`: builds live and corrected occupancy grid maps
+- `SlamLocalization`: does local scan matching against the current map
+- `LoopClosure`: stores keyframes, detects returns to old places, and applies simple correction
+
+The shared data types live in:
+
+```text
+src/slam/include/slam/simple_slam_types.hpp
+```
+
+This includes `Pose2D`, `KeyFrame`, `SimpleSlamConfig`, and result structs.
+
+This structure is intentionally not split too much.
+The goal is to keep each big concept separate while still making the full SLAM pipeline easy to follow.
+
 ## Inputs
 
 The node subscribes to:
@@ -197,6 +243,45 @@ This package also adds new learning methods:
 
 The correction is intentionally simple. It corrects the published keyframe trajectory and rebuilds `/corrected_map`. It does not change the live robot pose.
 
+## Parameters
+
+SLAM tuning lives in:
+
+```text
+src/slam/config/slam.yaml
+```
+
+The launch file loads this config:
+
+```bash
+ros2 launch slam simple_slam.launch.py
+```
+
+The main parameter groups are:
+
+- map size and resolution
+- log-odds update strength
+- scan matching search window and acceptance thresholds
+- movement threshold before map updates
+- keyframe spacing
+- loop-closure detection thresholds
+- loop-closure correction strength
+
+Important examples:
+
+- `resolution`: map cell size in meters
+- `width`, `height`: map size in cells
+- `scan_match_xy_range`: how far scan matching searches left/right/forward/back
+- `scan_match_theta_range`: how far scan matching searches in heading
+- `min_scan_match_score_improvement`: how much better the match must be than odometry
+- `keyframe_min_translation`: distance before saving a new keyframe
+- `loop_closure_search_radius`: how close poses must be before comparing scan signatures
+- `loop_closure_correction_strength`: how strongly accepted loop closures bend the corrected path
+
+The values are read when the node starts.
+If you edit `slam.yaml`, restart the SLAM launch file.
+This is runtime configuration: you can tune behavior without changing and rebuilding C++ code.
+
 ## Simple Loop-Closure Correction
 
 When loop closure says:
@@ -297,7 +382,7 @@ Current limits:
 - `/corrected_map` is rebuilt from keyframes only, so it may be less dense than `/map`
 - live `/estimated_pose` and live `/map` are not reset to the corrected trajectory
 - scan matching is still local and can fail in repeated geometry or large drift
-- tuning values are still hard-coded
+- parameters are loaded at startup, but they are not dynamically updated while the node runs
 
 It can correct small odometry errors, detect some returns to old places, show a simple corrected trajectory, and rebuild a keyframe-based corrected map.
 

--- a/src/slam/config/slam.yaml
+++ b/src/slam/config/slam.yaml
@@ -1,0 +1,43 @@
+/**:
+  ros__parameters:
+    resolution: 0.05
+    width: 500
+    height: 500
+    origin_x: -12.5
+    origin_y: -12.5
+
+    log_odds_hit: 2.89
+    log_odds_free: -2.25
+    log_odds_min: -10.0
+    log_odds_max: 10.0
+
+    min_occupied_cells_for_matching: 250
+    likelihood_max_distance: 1.0
+
+    scan_match_xy_range: 0.10
+    scan_match_xy_step: 0.05
+    scan_match_theta_range: 0.08
+    scan_match_theta_step: 0.04
+    scan_match_beam_step: 10
+    min_scan_match_score: 0.20
+    min_scan_match_score_improvement: 0.003
+    max_scan_match_translation_correction: 0.08
+    max_scan_match_rotation_correction: 0.08
+    min_scan_match_translation_interval: 0.02
+    min_scan_match_rotation_interval: 0.02
+    min_scan_match_scan_gap: 2
+    min_update_translation: 0.01
+    min_update_rotation: 0.01
+
+    keyframe_min_translation: 0.25
+    keyframe_min_rotation: 0.25
+    scan_signature_beam_step: 20
+    min_loop_closure_keyframe_age: 20
+    loop_closure_search_radius: 0.45
+    loop_closure_max_heading_diff: 0.70
+    loop_closure_max_signature_diff: 0.18
+    min_loop_closure_scan_gap: 20
+    min_correction_scan_gap: 80
+    min_correction_keyframe_gap: 12
+    min_old_keyframe_separation_for_correction: 8
+    loop_closure_correction_strength: 0.35

--- a/src/slam/include/slam/loop_closure.hpp
+++ b/src/slam/include/slam/loop_closure.hpp
@@ -21,7 +21,7 @@ public:
     const sensor_msgs::msg::LaserScan & scan,
     const Pose2D & slam_pose,
     int scan_index);
-  LoopClosureResult detect(int scans_integrated);
+  LoopClosureResult detectLoopClosure(int scans_integrated);
 
   const std::vector<KeyFrame> & keyframes() const;
   std::size_t keyframeCount() const;
@@ -29,11 +29,11 @@ public:
   int loopClosureCorrectionCount() const;
 
 private:
-  bool shouldApplyCorrection(
+  bool shouldApplyLoopClosureCorrection(
     std::size_t matched_keyframe_index,
     std::size_t current_keyframe_index,
     int scans_integrated) const;
-  void applyCorrection(
+  void applyLoopClosureCorrection(
     std::size_t matched_keyframe_index,
     std::size_t current_keyframe_index,
     int scans_integrated);

--- a/src/slam/include/slam/loop_closure.hpp
+++ b/src/slam/include/slam/loop_closure.hpp
@@ -1,0 +1,74 @@
+#ifndef SLAM__LOOP_CLOSURE_HPP_
+#define SLAM__LOOP_CLOSURE_HPP_
+
+#include "slam/simple_slam_types.hpp"
+
+#include "sensor_msgs/msg/laser_scan.hpp"
+
+#include <limits>
+#include <vector>
+
+namespace slam
+{
+
+class LoopClosure
+{
+public:
+  void configure(const SimpleSlamConfig & config);
+
+  bool shouldAddKeyFrame(const Pose2D & slam_pose) const;
+  void addKeyFrame(
+    const sensor_msgs::msg::LaserScan & scan,
+    const Pose2D & slam_pose,
+    int scan_index);
+  LoopClosureResult detect(int scans_integrated);
+
+  const std::vector<KeyFrame> & keyframes() const;
+  std::size_t keyframeCount() const;
+  int loopClosureCount() const;
+  int loopClosureCorrectionCount() const;
+
+private:
+  bool shouldApplyCorrection(
+    std::size_t matched_keyframe_index,
+    std::size_t current_keyframe_index,
+    int scans_integrated) const;
+  void applyCorrection(
+    std::size_t matched_keyframe_index,
+    std::size_t current_keyframe_index,
+    int scans_integrated);
+  StoredScan makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const;
+  std::vector<float> makeScanSignature(const sensor_msgs::msg::LaserScan & scan) const;
+  double scanSignatureDifference(
+    const std::vector<float> & first,
+    const std::vector<float> & second) const;
+  double poseDistance(const Pose2D & first, const Pose2D & second) const;
+  double normalizeAngle(double angle) const;
+
+  double keyframe_min_translation_ = 0.25;
+  double keyframe_min_rotation_ = 0.25;
+  std::size_t scan_signature_beam_step_ = 20;
+  int min_loop_closure_keyframe_age_ = 20;
+  double loop_closure_search_radius_ = 0.45;
+  double loop_closure_max_heading_diff_ = 0.70;
+  double loop_closure_max_signature_diff_ = 0.18;
+  int min_loop_closure_scan_gap_ = 20;
+  int min_correction_scan_gap_ = 80;
+  std::size_t min_correction_keyframe_gap_ = 12;
+  std::size_t min_old_keyframe_separation_for_correction_ = 8;
+  double loop_closure_correction_strength_ = 0.35;
+
+  std::vector<KeyFrame> keyframes_;
+  Pose2D last_keyframe_pose_;
+  bool keyframe_initialized_ = false;
+
+  int loop_closure_count_ = 0;
+  int loop_closure_correction_count_ = 0;
+  int last_loop_closure_scan_index_ = -100000;
+  int last_correction_scan_index_ = -100000;
+  std::size_t last_corrected_matched_keyframe_index_ = std::numeric_limits<std::size_t>::max();
+};
+
+}  // namespace slam
+
+#endif  // SLAM__LOOP_CLOSURE_HPP_

--- a/src/slam/include/slam/simple_slam.hpp
+++ b/src/slam/include/slam/simple_slam.hpp
@@ -1,0 +1,222 @@
+#ifndef SLAM__SIMPLE_SLAM_HPP_
+#define SLAM__SIMPLE_SLAM_HPP_
+
+#include "builtin_interfaces/msg/time.hpp"
+#include "geometry_msgs/msg/quaternion.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace slam
+{
+
+struct Pose2D
+{
+  double x = 0.0;
+  double y = 0.0;
+  double theta = 0.0;
+};
+
+struct ScanMatchResult
+{
+  Pose2D pose;
+  double score = 0.0;
+  double predicted_score = 0.0;
+  bool used_scan_matching = false;
+};
+
+struct StoredScan
+{
+  std::vector<float> ranges;
+  float angle_min = 0.0F;
+  float angle_increment = 0.0F;
+  float range_min = 0.0F;
+  float range_max = 0.0F;
+};
+
+struct KeyFrame
+{
+  Pose2D pose;
+  Pose2D corrected_pose;
+  std::vector<float> scan_signature;
+  StoredScan scan;
+  int scan_index = 0;
+};
+
+struct LoopClosureResult
+{
+  bool detected = false;
+  bool correction_applied = false;
+  Pose2D matched_pose;
+  std::size_t current_keyframe_index = 0;
+  std::size_t matched_keyframe_index = 0;
+  int matched_scan_index = 0;
+  double signature_difference = 0.0;
+};
+
+struct SlamUpdateResult
+{
+  bool scan_integrated = false;
+  bool stationary_scan_skipped = false;
+  bool map_updated = false;
+  bool corrected_map_updated = false;
+  bool trajectory_updated = false;
+  bool corrected_trajectory_updated = false;
+  bool keyframe_added = false;
+  ScanMatchResult scan_match;
+  LoopClosureResult loop_closure;
+};
+
+class SimpleSlam
+{
+public:
+  SimpleSlam();
+
+  bool handleOdometry(const nav_msgs::msg::Odometry & msg);
+  SlamUpdateResult handleScan(
+    const sensor_msgs::msg::LaserScan & scan,
+    const builtin_interfaces::msg::Time & stamp);
+
+  bool hasOdometry() const;
+  const Pose2D & slamPose() const;
+  const Pose2D & currentOdomPose() const;
+
+  const nav_msgs::msg::OccupancyGrid & map() const;
+  const nav_msgs::msg::OccupancyGrid & correctedMap() const;
+  const nav_msgs::msg::Path & trajectory() const;
+  const nav_msgs::msg::Path & correctedTrajectory() const;
+
+  int scansIntegrated() const;
+  int stationaryScansSkipped() const;
+  int scanMatchUsedCount() const;
+  int loopClosureCount() const;
+  int loopClosureCorrectionCount() const;
+  int occupiedCellCount() const;
+  std::size_t keyframeCount() const;
+
+private:
+  void initializeMap();
+  void rebuildLikelihoodField();
+  ScanMatchResult matchScan(const sensor_msgs::msg::LaserScan & scan, const Pose2D & predicted);
+  double scoreScanAtPose(const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose) const;
+  double likelihoodAtWorld(double x, double y) const;
+
+  void updateMapWithScan(const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose);
+  void insertScanIntoLogOddsMap(
+    const StoredScan & scan,
+    const Pose2D & pose,
+    std::vector<double> & log_odds_map);
+  void rebuildCorrectedMap(const builtin_interfaces::msg::Time & stamp);
+  void updateMapMessage(const builtin_interfaces::msg::Time & stamp);
+  void updateCorrectedMapMessage(const builtin_interfaces::msg::Time & stamp);
+  void updateTrajectory(const builtin_interfaces::msg::Time & stamp);
+  void updateCorrectedTrajectory(const builtin_interfaces::msg::Time & stamp);
+
+  bool shouldAddKeyFrame() const;
+  void addKeyFrame(const sensor_msgs::msg::LaserScan & scan);
+  LoopClosureResult detectLoopClosure();
+  bool shouldApplyLoopClosureCorrection(
+    std::size_t old_index,
+    std::size_t current_index) const;
+  void applyLoopClosureCorrection(std::size_t old_index, std::size_t current_index);
+  StoredScan makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const;
+  std::vector<float> makeScanSignature(const sensor_msgs::msg::LaserScan & scan) const;
+  double scanSignatureDifference(
+    const std::vector<float> & first,
+    const std::vector<float> & second) const;
+  double poseDistance(const Pose2D & first, const Pose2D & second) const;
+
+  Pose2D odomMsgToPose(const nav_msgs::msg::Odometry & msg) const;
+  Pose2D applyOdomDeltaToSlamPose(const Pose2D & old_odom, const Pose2D & new_odom) const;
+  bool odomMovedEnough(const Pose2D & old_odom, const Pose2D & new_odom) const;
+  geometry_msgs::msg::Quaternion yawToQuaternion(double yaw) const;
+
+  void worldToGrid(double wx, double wy, int & gx, int & gy) const;
+  bool isValidCell(int x, int y) const;
+  std::vector<std::pair<int, int>> bresenhamLine(int x0, int y0, int x1, int y1) const;
+  double normalizeAngle(double angle) const;
+  double clamp(double value, double low, double high) const;
+
+  nav_msgs::msg::OccupancyGrid map_msg_;
+  nav_msgs::msg::OccupancyGrid corrected_map_msg_;
+  nav_msgs::msg::OccupancyGrid likelihood_field_msg_;
+  nav_msgs::msg::Path trajectory_msg_;
+  nav_msgs::msg::Path corrected_trajectory_msg_;
+  std::vector<double> map_log_odds_;
+  std::vector<double> corrected_map_log_odds_;
+  std::vector<KeyFrame> keyframes_;
+
+  Pose2D slam_pose_;
+  Pose2D last_odom_pose_;
+  Pose2D current_odom_pose_;
+  Pose2D last_keyframe_pose_;
+  Pose2D last_scan_match_pose_;
+  bool odom_initialized_ = false;
+  bool scan_received_ = false;
+  bool keyframe_initialized_ = false;
+  bool scan_match_pose_initialized_ = false;
+
+  double resolution_ = 0.05;
+  int width_ = 500;
+  int height_ = 500;
+  double origin_x_ = -12.5;
+  double origin_y_ = -12.5;
+
+  double log_odds_hit_ = 2.89;
+  double log_odds_free_ = -2.25;
+  double log_odds_min_ = -10.0;
+  double log_odds_max_ = 10.0;
+
+  int occupied_cell_count_ = 0;
+  int min_occupied_cells_for_matching_ = 250;
+  bool likelihood_field_dirty_ = true;
+  double likelihood_max_distance_ = 1.0;
+
+  double search_xy_range_ = 0.10;
+  double search_xy_step_ = 0.05;
+  double search_theta_range_ = 0.08;
+  double search_theta_step_ = 0.04;
+  std::size_t scan_match_beam_step_ = 10;
+  double min_scan_match_score_ = 0.20;
+  double min_scan_match_score_improvement_ = 0.003;
+  double max_scan_match_translation_correction_ = 0.08;
+  double max_scan_match_rotation_correction_ = 0.08;
+  double min_scan_match_translation_interval_ = 0.02;
+  double min_scan_match_rotation_interval_ = 0.02;
+  int min_scan_match_scan_gap_ = 2;
+  double min_update_translation_ = 0.01;
+  double min_update_rotation_ = 0.01;
+
+  double keyframe_min_translation_ = 0.25;
+  double keyframe_min_rotation_ = 0.25;
+  std::size_t scan_signature_beam_step_ = 20;
+  int min_loop_closure_keyframe_age_ = 20;
+  double loop_closure_search_radius_ = 0.45;
+  double loop_closure_max_heading_diff_ = 0.70;
+  double loop_closure_max_signature_diff_ = 0.18;
+  int min_loop_closure_scan_gap_ = 20;
+  int min_correction_scan_gap_ = 80;
+  std::size_t min_correction_keyframe_gap_ = 12;
+  std::size_t min_old_keyframe_separation_for_correction_ = 8;
+  double loop_closure_correction_strength_ = 0.35;
+
+  int scans_integrated_ = 0;
+  int stationary_scans_skipped_ = 0;
+  int scan_match_used_count_ = 0;
+  int loop_closure_count_ = 0;
+  int loop_closure_correction_count_ = 0;
+  int last_scan_match_scan_ = -100000;
+  int last_loop_closure_scan_ = -100000;
+  int last_correction_scan_ = -100000;
+  std::size_t last_corrected_old_keyframe_ = std::numeric_limits<std::size_t>::max();
+};
+
+}  // namespace slam
+
+#endif  // SLAM__SIMPLE_SLAM_HPP_

--- a/src/slam/include/slam/simple_slam.hpp
+++ b/src/slam/include/slam/simple_slam.hpp
@@ -1,6 +1,11 @@
 #ifndef SLAM__SIMPLE_SLAM_HPP_
 #define SLAM__SIMPLE_SLAM_HPP_
 
+#include "slam/loop_closure.hpp"
+#include "slam/simple_slam_types.hpp"
+#include "slam/slam_localization.hpp"
+#include "slam/slam_mapper.hpp"
+
 #include "builtin_interfaces/msg/time.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
@@ -9,114 +14,9 @@
 #include "sensor_msgs/msg/laser_scan.hpp"
 
 #include <cstddef>
-#include <limits>
-#include <utility>
-#include <vector>
 
 namespace slam
 {
-
-struct Pose2D
-{
-  double x = 0.0;
-  double y = 0.0;
-  double theta = 0.0;
-};
-
-struct ScanMatchResult
-{
-  Pose2D pose;
-  double score = 0.0;
-  double predicted_score = 0.0;
-  bool used_scan_matching = false;
-};
-
-struct StoredScan
-{
-  std::vector<float> ranges;
-  float angle_min = 0.0F;
-  float angle_increment = 0.0F;
-  float range_min = 0.0F;
-  float range_max = 0.0F;
-};
-
-struct KeyFrame
-{
-  Pose2D pose;
-  Pose2D corrected_pose;
-  std::vector<float> scan_signature;
-  StoredScan scan;
-  int scan_index = 0;
-};
-
-struct SimpleSlamConfig
-{
-  double resolution = 0.05;
-  int width = 500;
-  int height = 500;
-  double origin_x = -12.5;
-  double origin_y = -12.5;
-
-  double log_odds_hit = 2.89;
-  double log_odds_free = -2.25;
-  double log_odds_min = -10.0;
-  double log_odds_max = 10.0;
-
-  int min_occupied_cells_for_matching = 250;
-  double likelihood_max_distance = 1.0;
-
-  double scan_match_xy_range = 0.10;
-  double scan_match_xy_step = 0.05;
-  double scan_match_theta_range = 0.08;
-  double scan_match_theta_step = 0.04;
-  std::size_t scan_match_beam_step = 10;
-  double min_scan_match_score = 0.20;
-  double min_scan_match_score_improvement = 0.003;
-  double max_scan_match_translation_correction = 0.08;
-  double max_scan_match_rotation_correction = 0.08;
-  double min_scan_match_translation_interval = 0.02;
-  double min_scan_match_rotation_interval = 0.02;
-  int min_scan_match_scan_gap = 2;
-  double min_update_translation = 0.01;
-  double min_update_rotation = 0.01;
-
-  double keyframe_min_translation = 0.25;
-  double keyframe_min_rotation = 0.25;
-  std::size_t scan_signature_beam_step = 20;
-  int min_loop_closure_keyframe_age = 20;
-  double loop_closure_search_radius = 0.45;
-  double loop_closure_max_heading_diff = 0.70;
-  double loop_closure_max_signature_diff = 0.18;
-  int min_loop_closure_scan_gap = 20;
-  int min_correction_scan_gap = 80;
-  std::size_t min_correction_keyframe_gap = 12;
-  std::size_t min_old_keyframe_separation_for_correction = 8;
-  double loop_closure_correction_strength = 0.35;
-};
-
-struct LoopClosureResult
-{
-  bool detected = false;
-  bool correction_applied = false;
-  Pose2D matched_pose;
-  std::size_t current_keyframe_index = 0;
-  std::size_t matched_keyframe_index = 0;
-  int matched_scan_index = 0;
-  double signature_difference = 0.0;
-};
-
-struct SlamUpdateResult
-{
-  bool scan_integrated = false;
-  bool stationary_scan_skipped = false;
-  bool map_updated = false;
-  bool corrected_map_updated = false;
-  bool trajectory_updated = false;
-  bool corrected_trajectory_updated = false;
-  bool keyframe_added = false;
-  ScanMatchResult scan_match;
-  LoopClosureResult loop_closure;
-};
 
 class SimpleSlam
 {
@@ -148,124 +48,34 @@ public:
   std::size_t keyframeCount() const;
 
 private:
-  void initializeMap();
-  void rebuildLikelihoodField();
-  ScanMatchResult matchScan(const sensor_msgs::msg::LaserScan & scan, const Pose2D & predicted);
-  double scoreScanAtPose(const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose) const;
-  double likelihoodAtWorld(double x, double y) const;
-
-  void updateMapWithScan(const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose);
-  void insertScanIntoLogOddsMap(
-    const StoredScan & scan,
-    const Pose2D & pose,
-    std::vector<double> & log_odds_map);
-  void rebuildCorrectedMap(const builtin_interfaces::msg::Time & stamp);
-  void updateMapMessage(const builtin_interfaces::msg::Time & stamp);
-  void updateCorrectedMapMessage(const builtin_interfaces::msg::Time & stamp);
   void updateTrajectory(const builtin_interfaces::msg::Time & stamp);
   void updateCorrectedTrajectory(const builtin_interfaces::msg::Time & stamp);
-
-  bool shouldAddKeyFrame() const;
-  void addKeyFrame(const sensor_msgs::msg::LaserScan & scan);
-  LoopClosureResult detectLoopClosure();
-  bool shouldApplyLoopClosureCorrection(
-    std::size_t matched_keyframe_index,
-    std::size_t current_keyframe_index) const;
-  void applyLoopClosureCorrection(
-    std::size_t matched_keyframe_index,
-    std::size_t current_keyframe_index);
-  StoredScan makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const;
-  std::vector<float> makeScanSignature(const sensor_msgs::msg::LaserScan & scan) const;
-  double scanSignatureDifference(
-    const std::vector<float> & first,
-    const std::vector<float> & second) const;
-  double poseDistance(const Pose2D & first, const Pose2D & second) const;
 
   Pose2D odomMsgToPose(const nav_msgs::msg::Odometry & msg) const;
   Pose2D applyOdomDeltaToSlamPose(const Pose2D & old_odom, const Pose2D & new_odom) const;
   bool odomMovedEnough(const Pose2D & old_odom, const Pose2D & new_odom) const;
   geometry_msgs::msg::Quaternion yawToQuaternion(double yaw) const;
-
-  void worldToGrid(double wx, double wy, int & gx, int & gy) const;
-  bool isValidCell(int x, int y) const;
-  std::vector<std::pair<int, int>> bresenhamLine(int x0, int y0, int x1, int y1) const;
   double normalizeAngle(double angle) const;
-  double clamp(double value, double low, double high) const;
 
-  nav_msgs::msg::OccupancyGrid map_msg_;
-  nav_msgs::msg::OccupancyGrid corrected_map_msg_;
-  nav_msgs::msg::OccupancyGrid likelihood_field_msg_;
+  SimpleSlamConfig config_;
+  SlamMapper mapper_;
+  SlamLocalization localization_;
+  LoopClosure loop_closure_;
+
   nav_msgs::msg::Path trajectory_msg_;
   nav_msgs::msg::Path corrected_trajectory_msg_;
-  std::vector<double> map_log_odds_;
-  std::vector<double> corrected_map_log_odds_;
-  std::vector<KeyFrame> keyframes_;
 
   Pose2D slam_pose_;
   Pose2D last_odom_pose_;
   Pose2D current_odom_pose_;
-  Pose2D last_keyframe_pose_;
-  Pose2D last_scan_match_pose_;
   bool odom_initialized_ = false;
   bool scan_received_ = false;
-  bool keyframe_initialized_ = false;
-  bool scan_match_pose_initialized_ = false;
 
-  double resolution_ = 0.05;
-  int width_ = 500;
-  int height_ = 500;
-  double origin_x_ = -12.5;
-  double origin_y_ = -12.5;
-
-  double log_odds_hit_ = 2.89;
-  double log_odds_free_ = -2.25;
-  double log_odds_min_ = -10.0;
-  double log_odds_max_ = 10.0;
-
-  int occupied_cell_count_ = 0;
-  int min_occupied_cells_for_matching_ = 250;
-  bool likelihood_field_dirty_ = true;
-  double likelihood_max_distance_ = 1.0;
-
-  double scan_match_xy_range_ = 0.10;
-  double scan_match_xy_step_ = 0.05;
-  double scan_match_theta_range_ = 0.08;
-  double scan_match_theta_step_ = 0.04;
-  std::size_t scan_match_beam_step_ = 10;
-  double min_scan_match_score_ = 0.20;
-  double min_scan_match_score_improvement_ = 0.003;
-  double max_scan_match_translation_correction_ = 0.08;
-  double max_scan_match_rotation_correction_ = 0.08;
-  double min_scan_match_translation_interval_ = 0.02;
-  double min_scan_match_rotation_interval_ = 0.02;
-  int min_scan_match_scan_gap_ = 2;
   double min_update_translation_ = 0.01;
   double min_update_rotation_ = 0.01;
 
-  double keyframe_min_translation_ = 0.25;
-  double keyframe_min_rotation_ = 0.25;
-  std::size_t scan_signature_beam_step_ = 20;
-  int min_loop_closure_keyframe_age_ = 20;
-  double loop_closure_search_radius_ = 0.45;
-  double loop_closure_max_heading_diff_ = 0.70;
-  double loop_closure_max_signature_diff_ = 0.18;
-  int min_loop_closure_scan_gap_ = 20;
-  int min_correction_scan_gap_ = 80;
-  std::size_t min_correction_keyframe_gap_ = 12;
-  std::size_t min_old_keyframe_separation_for_correction_ = 8;
-  double loop_closure_correction_strength_ = 0.35;
-
-  SimpleSlamConfig config_;
-
   int scans_integrated_ = 0;
   int stationary_scans_skipped_ = 0;
-  int scan_match_used_count_ = 0;
-  int loop_closure_count_ = 0;
-  int loop_closure_correction_count_ = 0;
-  int last_scan_match_scan_index_ = -100000;
-  int last_loop_closure_scan_index_ = -100000;
-  int last_correction_scan_index_ = -100000;
-  std::size_t last_corrected_matched_keyframe_index_ = std::numeric_limits<std::size_t>::max();
 };
 
 }  // namespace slam

--- a/src/slam/include/slam/simple_slam.hpp
+++ b/src/slam/include/slam/simple_slam.hpp
@@ -49,6 +49,51 @@ struct KeyFrame
   int scan_index = 0;
 };
 
+struct SimpleSlamConfig
+{
+  double resolution = 0.05;
+  int width = 500;
+  int height = 500;
+  double origin_x = -12.5;
+  double origin_y = -12.5;
+
+  double log_odds_hit = 2.89;
+  double log_odds_free = -2.25;
+  double log_odds_min = -10.0;
+  double log_odds_max = 10.0;
+
+  int min_occupied_cells_for_matching = 250;
+  double likelihood_max_distance = 1.0;
+
+  double scan_match_xy_range = 0.10;
+  double scan_match_xy_step = 0.05;
+  double scan_match_theta_range = 0.08;
+  double scan_match_theta_step = 0.04;
+  std::size_t scan_match_beam_step = 10;
+  double min_scan_match_score = 0.20;
+  double min_scan_match_score_improvement = 0.003;
+  double max_scan_match_translation_correction = 0.08;
+  double max_scan_match_rotation_correction = 0.08;
+  double min_scan_match_translation_interval = 0.02;
+  double min_scan_match_rotation_interval = 0.02;
+  int min_scan_match_scan_gap = 2;
+  double min_update_translation = 0.01;
+  double min_update_rotation = 0.01;
+
+  double keyframe_min_translation = 0.25;
+  double keyframe_min_rotation = 0.25;
+  std::size_t scan_signature_beam_step = 20;
+  int min_loop_closure_keyframe_age = 20;
+  double loop_closure_search_radius = 0.45;
+  double loop_closure_max_heading_diff = 0.70;
+  double loop_closure_max_signature_diff = 0.18;
+  int min_loop_closure_scan_gap = 20;
+  int min_correction_scan_gap = 80;
+  std::size_t min_correction_keyframe_gap = 12;
+  std::size_t min_old_keyframe_separation_for_correction = 8;
+  double loop_closure_correction_strength = 0.35;
+};
+
 struct LoopClosureResult
 {
   bool detected = false;
@@ -77,6 +122,8 @@ class SimpleSlam
 {
 public:
   SimpleSlam();
+
+  void configure(const SimpleSlamConfig & config);
 
   bool handleOdometry(const nav_msgs::msg::Odometry & msg);
   SlamUpdateResult handleScan(
@@ -122,9 +169,11 @@ private:
   void addKeyFrame(const sensor_msgs::msg::LaserScan & scan);
   LoopClosureResult detectLoopClosure();
   bool shouldApplyLoopClosureCorrection(
-    std::size_t old_index,
-    std::size_t current_index) const;
-  void applyLoopClosureCorrection(std::size_t old_index, std::size_t current_index);
+    std::size_t matched_keyframe_index,
+    std::size_t current_keyframe_index) const;
+  void applyLoopClosureCorrection(
+    std::size_t matched_keyframe_index,
+    std::size_t current_keyframe_index);
   StoredScan makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const;
   std::vector<float> makeScanSignature(const sensor_msgs::msg::LaserScan & scan) const;
   double scanSignatureDifference(
@@ -178,10 +227,10 @@ private:
   bool likelihood_field_dirty_ = true;
   double likelihood_max_distance_ = 1.0;
 
-  double search_xy_range_ = 0.10;
-  double search_xy_step_ = 0.05;
-  double search_theta_range_ = 0.08;
-  double search_theta_step_ = 0.04;
+  double scan_match_xy_range_ = 0.10;
+  double scan_match_xy_step_ = 0.05;
+  double scan_match_theta_range_ = 0.08;
+  double scan_match_theta_step_ = 0.04;
   std::size_t scan_match_beam_step_ = 10;
   double min_scan_match_score_ = 0.20;
   double min_scan_match_score_improvement_ = 0.003;
@@ -206,15 +255,17 @@ private:
   std::size_t min_old_keyframe_separation_for_correction_ = 8;
   double loop_closure_correction_strength_ = 0.35;
 
+  SimpleSlamConfig config_;
+
   int scans_integrated_ = 0;
   int stationary_scans_skipped_ = 0;
   int scan_match_used_count_ = 0;
   int loop_closure_count_ = 0;
   int loop_closure_correction_count_ = 0;
-  int last_scan_match_scan_ = -100000;
-  int last_loop_closure_scan_ = -100000;
-  int last_correction_scan_ = -100000;
-  std::size_t last_corrected_old_keyframe_ = std::numeric_limits<std::size_t>::max();
+  int last_scan_match_scan_index_ = -100000;
+  int last_loop_closure_scan_index_ = -100000;
+  int last_correction_scan_index_ = -100000;
+  std::size_t last_corrected_matched_keyframe_index_ = std::numeric_limits<std::size_t>::max();
 };
 
 }  // namespace slam

--- a/src/slam/include/slam/simple_slam_types.hpp
+++ b/src/slam/include/slam/simple_slam_types.hpp
@@ -1,0 +1,114 @@
+#ifndef SLAM__SIMPLE_SLAM_TYPES_HPP_
+#define SLAM__SIMPLE_SLAM_TYPES_HPP_
+
+#include <cstddef>
+#include <vector>
+
+namespace slam
+{
+
+struct Pose2D
+{
+  double x = 0.0;
+  double y = 0.0;
+  double theta = 0.0;
+};
+
+struct ScanMatchResult
+{
+  Pose2D pose;
+  double score = 0.0;
+  double predicted_score = 0.0;
+  bool used_scan_matching = false;
+};
+
+struct StoredScan
+{
+  std::vector<float> ranges;
+  float angle_min = 0.0F;
+  float angle_increment = 0.0F;
+  float range_min = 0.0F;
+  float range_max = 0.0F;
+};
+
+struct KeyFrame
+{
+  Pose2D pose;
+  Pose2D corrected_pose;
+  std::vector<float> scan_signature;
+  StoredScan scan;
+  int scan_index = 0;
+};
+
+struct SimpleSlamConfig
+{
+  double resolution = 0.05;
+  int width = 500;
+  int height = 500;
+  double origin_x = -12.5;
+  double origin_y = -12.5;
+
+  double log_odds_hit = 2.89;
+  double log_odds_free = -2.25;
+  double log_odds_min = -10.0;
+  double log_odds_max = 10.0;
+
+  int min_occupied_cells_for_matching = 250;
+  double likelihood_max_distance = 1.0;
+
+  double scan_match_xy_range = 0.10;
+  double scan_match_xy_step = 0.05;
+  double scan_match_theta_range = 0.08;
+  double scan_match_theta_step = 0.04;
+  std::size_t scan_match_beam_step = 10;
+  double min_scan_match_score = 0.20;
+  double min_scan_match_score_improvement = 0.003;
+  double max_scan_match_translation_correction = 0.08;
+  double max_scan_match_rotation_correction = 0.08;
+  double min_scan_match_translation_interval = 0.02;
+  double min_scan_match_rotation_interval = 0.02;
+  int min_scan_match_scan_gap = 2;
+  double min_update_translation = 0.01;
+  double min_update_rotation = 0.01;
+
+  double keyframe_min_translation = 0.25;
+  double keyframe_min_rotation = 0.25;
+  std::size_t scan_signature_beam_step = 20;
+  int min_loop_closure_keyframe_age = 20;
+  double loop_closure_search_radius = 0.45;
+  double loop_closure_max_heading_diff = 0.70;
+  double loop_closure_max_signature_diff = 0.18;
+  int min_loop_closure_scan_gap = 20;
+  int min_correction_scan_gap = 80;
+  std::size_t min_correction_keyframe_gap = 12;
+  std::size_t min_old_keyframe_separation_for_correction = 8;
+  double loop_closure_correction_strength = 0.35;
+};
+
+struct LoopClosureResult
+{
+  bool detected = false;
+  bool correction_applied = false;
+  Pose2D matched_pose;
+  std::size_t current_keyframe_index = 0;
+  std::size_t matched_keyframe_index = 0;
+  int matched_scan_index = 0;
+  double signature_difference = 0.0;
+};
+
+struct SlamUpdateResult
+{
+  bool scan_integrated = false;
+  bool stationary_scan_skipped = false;
+  bool map_updated = false;
+  bool corrected_map_updated = false;
+  bool trajectory_updated = false;
+  bool corrected_trajectory_updated = false;
+  bool keyframe_added = false;
+  ScanMatchResult scan_match;
+  LoopClosureResult loop_closure;
+};
+
+}  // namespace slam
+
+#endif  // SLAM__SIMPLE_SLAM_TYPES_HPP_

--- a/src/slam/include/slam/slam_localization.hpp
+++ b/src/slam/include/slam/slam_localization.hpp
@@ -13,7 +13,7 @@ class SlamLocalization
 {
 public:
   void configure(const SimpleSlamConfig & config);
-  void markMapDirty();
+  void markMapDirtyForScanMatching();
 
   ScanMatchResult matchScan(
     const sensor_msgs::msg::LaserScan & scan,

--- a/src/slam/include/slam/slam_localization.hpp
+++ b/src/slam/include/slam/slam_localization.hpp
@@ -1,0 +1,66 @@
+#ifndef SLAM__SLAM_LOCALIZATION_HPP_
+#define SLAM__SLAM_LOCALIZATION_HPP_
+
+#include "slam/simple_slam_types.hpp"
+
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+
+namespace slam
+{
+
+class SlamLocalization
+{
+public:
+  void configure(const SimpleSlamConfig & config);
+  void markMapDirty();
+
+  ScanMatchResult matchScan(
+    const sensor_msgs::msg::LaserScan & scan,
+    const Pose2D & predicted_pose,
+    const nav_msgs::msg::OccupancyGrid & map,
+    bool scan_received,
+    int scans_integrated,
+    int occupied_cell_count);
+
+  int scanMatchUsedCount() const;
+
+private:
+  void rebuildLikelihoodField(const nav_msgs::msg::OccupancyGrid & map);
+  double scoreScanAtPose(
+    const sensor_msgs::msg::LaserScan & scan,
+    const Pose2D & pose) const;
+  double likelihoodAtWorld(double x, double y) const;
+  bool worldToGrid(double wx, double wy, int & gx, int & gy) const;
+  bool isValidCell(int x, int y) const;
+  double normalizeAngle(double angle) const;
+  double poseDistance(const Pose2D & first, const Pose2D & second) const;
+
+  int min_occupied_cells_for_matching_ = 250;
+  bool likelihood_field_dirty_ = true;
+  double likelihood_max_distance_ = 1.0;
+
+  double scan_match_xy_range_ = 0.10;
+  double scan_match_xy_step_ = 0.05;
+  double scan_match_theta_range_ = 0.08;
+  double scan_match_theta_step_ = 0.04;
+  std::size_t scan_match_beam_step_ = 10;
+  double min_scan_match_score_ = 0.20;
+  double min_scan_match_score_improvement_ = 0.003;
+  double max_scan_match_translation_correction_ = 0.08;
+  double max_scan_match_rotation_correction_ = 0.08;
+  double min_scan_match_translation_interval_ = 0.02;
+  double min_scan_match_rotation_interval_ = 0.02;
+  int min_scan_match_scan_gap_ = 2;
+
+  Pose2D last_scan_match_pose_;
+  bool scan_match_pose_initialized_ = false;
+  int scan_match_used_count_ = 0;
+  int last_scan_match_scan_index_ = -100000;
+
+  nav_msgs::msg::OccupancyGrid likelihood_field_msg_;
+};
+
+}  // namespace slam
+
+#endif  // SLAM__SLAM_LOCALIZATION_HPP_

--- a/src/slam/include/slam/slam_mapper.hpp
+++ b/src/slam/include/slam/slam_mapper.hpp
@@ -1,0 +1,68 @@
+#ifndef SLAM__SLAM_MAPPER_HPP_
+#define SLAM__SLAM_MAPPER_HPP_
+
+#include "slam/simple_slam_types.hpp"
+
+#include "builtin_interfaces/msg/time.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+
+#include <utility>
+#include <vector>
+
+namespace slam
+{
+
+class SlamMapper
+{
+public:
+  void configure(const SimpleSlamConfig & config);
+
+  void updateWithScan(
+    const sensor_msgs::msg::LaserScan & scan,
+    const Pose2D & pose,
+    const builtin_interfaces::msg::Time & stamp);
+  void rebuildCorrectedMap(
+    const std::vector<KeyFrame> & keyframes,
+    const builtin_interfaces::msg::Time & stamp);
+
+  const nav_msgs::msg::OccupancyGrid & map() const;
+  const nav_msgs::msg::OccupancyGrid & correctedMap() const;
+  int occupiedCellCount() const;
+
+private:
+  void initializeMap();
+  void insertScanIntoLogOddsMap(
+    const StoredScan & scan,
+    const Pose2D & pose,
+    std::vector<double> & log_odds_map);
+  void updateMapMessage(const builtin_interfaces::msg::Time & stamp);
+  void updateCorrectedMapMessage(const builtin_interfaces::msg::Time & stamp);
+  StoredScan makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const;
+
+  void worldToGrid(double wx, double wy, int & gx, int & gy) const;
+  bool isValidCell(int x, int y) const;
+  std::vector<std::pair<int, int>> bresenhamLine(int x0, int y0, int x1, int y1) const;
+  double clamp(double value, double low, double high) const;
+
+  double resolution_ = 0.05;
+  int width_ = 500;
+  int height_ = 500;
+  double origin_x_ = -12.5;
+  double origin_y_ = -12.5;
+
+  double log_odds_hit_ = 2.89;
+  double log_odds_free_ = -2.25;
+  double log_odds_min_ = -10.0;
+  double log_odds_max_ = 10.0;
+
+  nav_msgs::msg::OccupancyGrid map_msg_;
+  nav_msgs::msg::OccupancyGrid corrected_map_msg_;
+  std::vector<double> map_log_odds_;
+  std::vector<double> corrected_map_log_odds_;
+  int occupied_cell_count_ = 0;
+};
+
+}  // namespace slam
+
+#endif  // SLAM__SLAM_MAPPER_HPP_

--- a/src/slam/launch/simple_slam.launch.py
+++ b/src/slam/launch/simple_slam.launch.py
@@ -1,13 +1,20 @@
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
+import os
+
 
 def generate_launch_description():
+    package_share_dir = get_package_share_directory('slam')
+    config_file = os.path.join(package_share_dir, 'config', 'slam.yaml')
+
     return LaunchDescription([
         Node(
             package='slam',
             executable='simple_slam_node',
             name='simple_slam_node',
             output='screen',
+            parameters=[config_file],
         ),
     ])

--- a/src/slam/src/loop_closure.cpp
+++ b/src/slam/src/loop_closure.cpp
@@ -60,7 +60,7 @@ void LoopClosure::addKeyFrame(
   keyframe_initialized_ = true;
 }
 
-LoopClosureResult LoopClosure::detect(int scans_integrated)
+LoopClosureResult LoopClosure::detectLoopClosure(int scans_integrated)
 {
   if (keyframes_.size() <= static_cast<std::size_t>(min_loop_closure_keyframe_age_)) {
     return {};
@@ -121,8 +121,10 @@ LoopClosureResult LoopClosure::detect(int scans_integrated)
   result.matched_scan_index = matched_keyframe.scan_index;
   result.signature_difference = best_signature_difference;
 
-  if (shouldApplyCorrection(best_candidate_index, current_keyframe_index, scans_integrated)) {
-    applyCorrection(best_candidate_index, current_keyframe_index, scans_integrated);
+  if (shouldApplyLoopClosureCorrection(
+      best_candidate_index, current_keyframe_index, scans_integrated))
+  {
+    applyLoopClosureCorrection(best_candidate_index, current_keyframe_index, scans_integrated);
     result.correction_applied = true;
   }
 
@@ -149,7 +151,7 @@ int LoopClosure::loopClosureCorrectionCount() const
   return loop_closure_correction_count_;
 }
 
-bool LoopClosure::shouldApplyCorrection(
+bool LoopClosure::shouldApplyLoopClosureCorrection(
   std::size_t matched_keyframe_index,
   std::size_t current_keyframe_index,
   int scans_integrated) const
@@ -180,7 +182,7 @@ bool LoopClosure::shouldApplyCorrection(
   return true;
 }
 
-void LoopClosure::applyCorrection(
+void LoopClosure::applyLoopClosureCorrection(
   std::size_t matched_keyframe_index,
   std::size_t current_keyframe_index,
   int scans_integrated)

--- a/src/slam/src/loop_closure.cpp
+++ b/src/slam/src/loop_closure.cpp
@@ -1,0 +1,284 @@
+#include "slam/loop_closure.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace slam
+{
+
+void LoopClosure::configure(const SimpleSlamConfig & config)
+{
+  keyframe_min_translation_ = config.keyframe_min_translation;
+  keyframe_min_rotation_ = config.keyframe_min_rotation;
+  scan_signature_beam_step_ = config.scan_signature_beam_step;
+  min_loop_closure_keyframe_age_ = config.min_loop_closure_keyframe_age;
+  loop_closure_search_radius_ = config.loop_closure_search_radius;
+  loop_closure_max_heading_diff_ = config.loop_closure_max_heading_diff;
+  loop_closure_max_signature_diff_ = config.loop_closure_max_signature_diff;
+  min_loop_closure_scan_gap_ = config.min_loop_closure_scan_gap;
+  min_correction_scan_gap_ = config.min_correction_scan_gap;
+  min_correction_keyframe_gap_ = config.min_correction_keyframe_gap;
+  min_old_keyframe_separation_for_correction_ =
+    config.min_old_keyframe_separation_for_correction;
+  loop_closure_correction_strength_ = config.loop_closure_correction_strength;
+
+  keyframes_.clear();
+  keyframe_initialized_ = false;
+  loop_closure_count_ = 0;
+  loop_closure_correction_count_ = 0;
+  last_loop_closure_scan_index_ = -100000;
+  last_correction_scan_index_ = -100000;
+  last_corrected_matched_keyframe_index_ = std::numeric_limits<std::size_t>::max();
+}
+
+bool LoopClosure::shouldAddKeyFrame(const Pose2D & slam_pose) const
+{
+  if (!keyframe_initialized_) {
+    return true;
+  }
+
+  double distance = poseDistance(slam_pose, last_keyframe_pose_);
+  double rotation = std::abs(normalizeAngle(slam_pose.theta - last_keyframe_pose_.theta));
+
+  return distance >= keyframe_min_translation_ || rotation >= keyframe_min_rotation_;
+}
+
+void LoopClosure::addKeyFrame(
+  const sensor_msgs::msg::LaserScan & scan,
+  const Pose2D & slam_pose,
+  int scan_index)
+{
+  KeyFrame keyframe;
+  keyframe.pose = slam_pose;
+  keyframe.corrected_pose = slam_pose;
+  keyframe.scan_signature = makeScanSignature(scan);
+  keyframe.scan = makeStoredScan(scan);
+  keyframe.scan_index = scan_index;
+
+  keyframes_.push_back(keyframe);
+  last_keyframe_pose_ = slam_pose;
+  keyframe_initialized_ = true;
+}
+
+LoopClosureResult LoopClosure::detect(int scans_integrated)
+{
+  if (keyframes_.size() <= static_cast<std::size_t>(min_loop_closure_keyframe_age_)) {
+    return {};
+  }
+
+  if (scans_integrated - last_loop_closure_scan_index_ < min_loop_closure_scan_gap_) {
+    return {};
+  }
+
+  std::size_t current_keyframe_index = keyframes_.size() - 1;
+  const KeyFrame & current_keyframe = keyframes_[current_keyframe_index];
+  double best_signature_difference = std::numeric_limits<double>::max();
+  std::size_t best_candidate_index = 0;
+  bool found_candidate = false;
+
+  for (std::size_t candidate_index = 0; candidate_index < current_keyframe_index;
+    ++candidate_index)
+  {
+    const KeyFrame & keyframe = keyframes_[candidate_index];
+    int keyframe_age = current_keyframe.scan_index - keyframe.scan_index;
+    if (keyframe_age < min_loop_closure_keyframe_age_) {
+      continue;
+    }
+
+    double distance = poseDistance(current_keyframe.pose, keyframe.pose);
+    if (distance > loop_closure_search_radius_) {
+      continue;
+    }
+
+    double heading_difference =
+      std::abs(normalizeAngle(current_keyframe.pose.theta - keyframe.pose.theta));
+    if (heading_difference > loop_closure_max_heading_diff_) {
+      continue;
+    }
+
+    double signature_difference =
+      scanSignatureDifference(current_keyframe.scan_signature, keyframe.scan_signature);
+    if (signature_difference < best_signature_difference) {
+      best_signature_difference = signature_difference;
+      best_candidate_index = candidate_index;
+      found_candidate = true;
+    }
+  }
+
+  if (!found_candidate || best_signature_difference > loop_closure_max_signature_diff_) {
+    return {};
+  }
+
+  loop_closure_count_++;
+  last_loop_closure_scan_index_ = scans_integrated;
+  const KeyFrame & matched_keyframe = keyframes_[best_candidate_index];
+
+  LoopClosureResult result;
+  result.detected = true;
+  result.matched_pose = matched_keyframe.pose;
+  result.current_keyframe_index = current_keyframe_index;
+  result.matched_keyframe_index = best_candidate_index;
+  result.matched_scan_index = matched_keyframe.scan_index;
+  result.signature_difference = best_signature_difference;
+
+  if (shouldApplyCorrection(best_candidate_index, current_keyframe_index, scans_integrated)) {
+    applyCorrection(best_candidate_index, current_keyframe_index, scans_integrated);
+    result.correction_applied = true;
+  }
+
+  return result;
+}
+
+const std::vector<KeyFrame> & LoopClosure::keyframes() const
+{
+  return keyframes_;
+}
+
+std::size_t LoopClosure::keyframeCount() const
+{
+  return keyframes_.size();
+}
+
+int LoopClosure::loopClosureCount() const
+{
+  return loop_closure_count_;
+}
+
+int LoopClosure::loopClosureCorrectionCount() const
+{
+  return loop_closure_correction_count_;
+}
+
+bool LoopClosure::shouldApplyCorrection(
+  std::size_t matched_keyframe_index,
+  std::size_t current_keyframe_index,
+  int scans_integrated) const
+{
+  if (current_keyframe_index <= matched_keyframe_index) {
+    return false;
+  }
+
+  if (current_keyframe_index - matched_keyframe_index < min_correction_keyframe_gap_) {
+    return false;
+  }
+
+  if (scans_integrated - last_correction_scan_index_ < min_correction_scan_gap_) {
+    return false;
+  }
+
+  if (last_corrected_matched_keyframe_index_ != std::numeric_limits<std::size_t>::max()) {
+    std::size_t separation =
+      matched_keyframe_index > last_corrected_matched_keyframe_index_ ?
+      matched_keyframe_index - last_corrected_matched_keyframe_index_ :
+      last_corrected_matched_keyframe_index_ - matched_keyframe_index;
+
+    if (separation < min_old_keyframe_separation_for_correction_) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void LoopClosure::applyCorrection(
+  std::size_t matched_keyframe_index,
+  std::size_t current_keyframe_index,
+  int scans_integrated)
+{
+  if (current_keyframe_index <= matched_keyframe_index ||
+    current_keyframe_index >= keyframes_.size())
+  {
+    return;
+  }
+
+  const Pose2D matched_pose = keyframes_[matched_keyframe_index].corrected_pose;
+  const Pose2D current_pose = keyframes_[current_keyframe_index].corrected_pose;
+
+  double error_x = loop_closure_correction_strength_ * (matched_pose.x - current_pose.x);
+  double error_y = loop_closure_correction_strength_ * (matched_pose.y - current_pose.y);
+  double error_theta =
+    loop_closure_correction_strength_ * normalizeAngle(matched_pose.theta - current_pose.theta);
+  double span = static_cast<double>(current_keyframe_index - matched_keyframe_index);
+
+  for (std::size_t keyframe_index = matched_keyframe_index + 1;
+    keyframe_index <= current_keyframe_index;
+    ++keyframe_index)
+  {
+    double fraction = static_cast<double>(keyframe_index - matched_keyframe_index) / span;
+    keyframes_[keyframe_index].corrected_pose.x += fraction * error_x;
+    keyframes_[keyframe_index].corrected_pose.y += fraction * error_y;
+    keyframes_[keyframe_index].corrected_pose.theta =
+      normalizeAngle(keyframes_[keyframe_index].corrected_pose.theta + fraction * error_theta);
+  }
+
+  loop_closure_correction_count_++;
+  last_correction_scan_index_ = scans_integrated;
+  last_corrected_matched_keyframe_index_ = matched_keyframe_index;
+}
+
+StoredScan LoopClosure::makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const
+{
+  StoredScan stored_scan;
+  stored_scan.ranges = scan.ranges;
+  stored_scan.angle_min = scan.angle_min;
+  stored_scan.angle_increment = scan.angle_increment;
+  stored_scan.range_min = scan.range_min;
+  stored_scan.range_max = scan.range_max;
+  return stored_scan;
+}
+
+std::vector<float> LoopClosure::makeScanSignature(
+  const sensor_msgs::msg::LaserScan & scan) const
+{
+  std::vector<float> signature;
+  signature.reserve(scan.ranges.size() / scan_signature_beam_step_ + 1);
+
+  for (std::size_t i = 0; i < scan.ranges.size(); i += scan_signature_beam_step_) {
+    float range = scan.ranges[i];
+    if (!std::isfinite(range) || range < scan.range_min) {
+      range = scan.range_max;
+    }
+
+    range = std::min(range, scan.range_max);
+    signature.push_back(range / scan.range_max);
+  }
+
+  return signature;
+}
+
+double LoopClosure::scanSignatureDifference(
+  const std::vector<float> & first,
+  const std::vector<float> & second) const
+{
+  std::size_t count = std::min(first.size(), second.size());
+  if (count == 0) {
+    return std::numeric_limits<double>::max();
+  }
+
+  double difference_sum = 0.0;
+  for (std::size_t i = 0; i < count; ++i) {
+    difference_sum += std::abs(first[i] - second[i]);
+  }
+
+  return difference_sum / count;
+}
+
+double LoopClosure::poseDistance(const Pose2D & first, const Pose2D & second) const
+{
+  double dx = first.x - second.x;
+  double dy = first.y - second.y;
+  return std::sqrt(dx * dx + dy * dy);
+}
+
+double LoopClosure::normalizeAngle(double angle) const
+{
+  while (angle > M_PI) {
+    angle -= 2.0 * M_PI;
+  }
+  while (angle < -M_PI) {
+    angle += 2.0 * M_PI;
+  }
+  return angle;
+}
+
+}  // namespace slam

--- a/src/slam/src/simple_slam.cpp
+++ b/src/slam/src/simple_slam.cpp
@@ -51,6 +51,7 @@ SlamUpdateResult SimpleSlam::handleScan(
     return update;
   }
 
+  // 1. Odometry gives the first guess for where the robot moved.
   bool moved_enough = odomMovedEnough(last_odom_pose_, current_odom_pose_);
   Pose2D predicted_pose = applyOdomDeltaToSlamPose(last_odom_pose_, current_odom_pose_);
   last_odom_pose_ = current_odom_pose_;
@@ -61,6 +62,7 @@ SlamUpdateResult SimpleSlam::handleScan(
     return update;
   }
 
+  // 2. Localization tries to improve the odometry guess by matching the scan to the map.
   update.scan_match = localization_.matchScan(
     scan,
     predicted_pose,
@@ -70,8 +72,9 @@ SlamUpdateResult SimpleSlam::handleScan(
     mapper_.occupiedCellCount());
   slam_pose_ = update.scan_match.pose;
 
+  // 3. Mapping inserts the scan using the best pose estimate.
   mapper_.updateWithScan(scan, slam_pose_, stamp);
-  localization_.markMapDirty();
+  localization_.markMapDirtyForScanMatching();
 
   scan_received_ = true;
   scans_integrated_++;
@@ -81,10 +84,11 @@ SlamUpdateResult SimpleSlam::handleScan(
   update.map_updated = true;
   update.trajectory_updated = true;
 
+  // 4. Loop closure saves keyframes and checks whether we returned to an old place.
   if (loop_closure_.shouldAddKeyFrame(slam_pose_)) {
     loop_closure_.addKeyFrame(scan, slam_pose_, scans_integrated_);
     update.keyframe_added = true;
-    update.loop_closure = loop_closure_.detect(scans_integrated_);
+    update.loop_closure = loop_closure_.detectLoopClosure(scans_integrated_);
     if (update.loop_closure.correction_applied) {
       updateCorrectedTrajectory(stamp);
       mapper_.rebuildCorrectedMap(loop_closure_.keyframes(), stamp);

--- a/src/slam/src/simple_slam.cpp
+++ b/src/slam/src/simple_slam.cpp
@@ -4,10 +4,7 @@
 #include "tf2/utils.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
-#include <algorithm>
 #include <cmath>
-#include <limits>
-#include <queue>
 
 namespace slam
 {
@@ -20,51 +17,15 @@ SimpleSlam::SimpleSlam()
 void SimpleSlam::configure(const SimpleSlamConfig & config)
 {
   config_ = config;
-
-  resolution_ = config_.resolution;
-  width_ = config_.width;
-  height_ = config_.height;
-  origin_x_ = config_.origin_x;
-  origin_y_ = config_.origin_y;
-
-  log_odds_hit_ = config_.log_odds_hit;
-  log_odds_free_ = config_.log_odds_free;
-  log_odds_min_ = config_.log_odds_min;
-  log_odds_max_ = config_.log_odds_max;
-
-  min_occupied_cells_for_matching_ = config_.min_occupied_cells_for_matching;
-  likelihood_max_distance_ = config_.likelihood_max_distance;
-
-  scan_match_xy_range_ = config_.scan_match_xy_range;
-  scan_match_xy_step_ = config_.scan_match_xy_step;
-  scan_match_theta_range_ = config_.scan_match_theta_range;
-  scan_match_theta_step_ = config_.scan_match_theta_step;
-  scan_match_beam_step_ = config_.scan_match_beam_step;
-  min_scan_match_score_ = config_.min_scan_match_score;
-  min_scan_match_score_improvement_ = config_.min_scan_match_score_improvement;
-  max_scan_match_translation_correction_ = config_.max_scan_match_translation_correction;
-  max_scan_match_rotation_correction_ = config_.max_scan_match_rotation_correction;
-  min_scan_match_translation_interval_ = config_.min_scan_match_translation_interval;
-  min_scan_match_rotation_interval_ = config_.min_scan_match_rotation_interval;
-  min_scan_match_scan_gap_ = config_.min_scan_match_scan_gap;
   min_update_translation_ = config_.min_update_translation;
   min_update_rotation_ = config_.min_update_rotation;
 
-  keyframe_min_translation_ = config_.keyframe_min_translation;
-  keyframe_min_rotation_ = config_.keyframe_min_rotation;
-  scan_signature_beam_step_ = config_.scan_signature_beam_step;
-  min_loop_closure_keyframe_age_ = config_.min_loop_closure_keyframe_age;
-  loop_closure_search_radius_ = config_.loop_closure_search_radius;
-  loop_closure_max_heading_diff_ = config_.loop_closure_max_heading_diff;
-  loop_closure_max_signature_diff_ = config_.loop_closure_max_signature_diff;
-  min_loop_closure_scan_gap_ = config_.min_loop_closure_scan_gap;
-  min_correction_scan_gap_ = config_.min_correction_scan_gap;
-  min_correction_keyframe_gap_ = config_.min_correction_keyframe_gap;
-  min_old_keyframe_separation_for_correction_ =
-    config_.min_old_keyframe_separation_for_correction;
-  loop_closure_correction_strength_ = config_.loop_closure_correction_strength;
+  mapper_.configure(config_);
+  localization_.configure(config_);
+  loop_closure_.configure(config_);
 
-  initializeMap();
+  trajectory_msg_.header.frame_id = "map";
+  corrected_trajectory_msg_.header.frame_id = "map";
 }
 
 bool SimpleSlam::handleOdometry(const nav_msgs::msg::Odometry & msg)
@@ -100,28 +61,33 @@ SlamUpdateResult SimpleSlam::handleScan(
     return update;
   }
 
-  update.scan_match = matchScan(scan, predicted_pose);
+  update.scan_match = localization_.matchScan(
+    scan,
+    predicted_pose,
+    mapper_.map(),
+    scan_received_,
+    scans_integrated_,
+    mapper_.occupiedCellCount());
   slam_pose_ = update.scan_match.pose;
 
-  updateMapWithScan(scan, slam_pose_);
-  updateMapMessage(stamp);
+  mapper_.updateWithScan(scan, slam_pose_, stamp);
+  localization_.markMapDirty();
 
   scan_received_ = true;
   scans_integrated_++;
-  likelihood_field_dirty_ = true;
   updateTrajectory(stamp);
 
   update.scan_integrated = true;
   update.map_updated = true;
   update.trajectory_updated = true;
 
-  if (shouldAddKeyFrame()) {
-    addKeyFrame(scan);
+  if (loop_closure_.shouldAddKeyFrame(slam_pose_)) {
+    loop_closure_.addKeyFrame(scan, slam_pose_, scans_integrated_);
     update.keyframe_added = true;
-    update.loop_closure = detectLoopClosure();
+    update.loop_closure = loop_closure_.detect(scans_integrated_);
     if (update.loop_closure.correction_applied) {
       updateCorrectedTrajectory(stamp);
-      rebuildCorrectedMap(stamp);
+      mapper_.rebuildCorrectedMap(loop_closure_.keyframes(), stamp);
       update.corrected_map_updated = true;
     }
   }
@@ -132,349 +98,74 @@ SlamUpdateResult SimpleSlam::handleScan(
   return update;
 }
 
-void SimpleSlam::initializeMap()
+bool SimpleSlam::hasOdometry() const
 {
-  map_log_odds_.assign(width_ * height_, 0.0);
-  corrected_map_log_odds_.assign(width_ * height_, 0.0);
-
-  map_msg_.header.frame_id = "map";
-  map_msg_.info.resolution = resolution_;
-  map_msg_.info.width = width_;
-  map_msg_.info.height = height_;
-  map_msg_.info.origin.position.x = origin_x_;
-  map_msg_.info.origin.position.y = origin_y_;
-  map_msg_.info.origin.orientation.w = 1.0;
-  map_msg_.data.assign(width_ * height_, -1);
-  corrected_map_msg_ = map_msg_;
-
-  likelihood_field_msg_ = map_msg_;
-  likelihood_field_msg_.data.assign(width_ * height_, 0);
-
-  trajectory_msg_.header.frame_id = "map";
-  corrected_trajectory_msg_.header.frame_id = "map";
+  return odom_initialized_;
 }
 
-Pose2D SimpleSlam::applyOdomDeltaToSlamPose(
-  const Pose2D & old_odom, const Pose2D & new_odom) const
+const Pose2D & SimpleSlam::slamPose() const
 {
-  double odom_dx = new_odom.x - old_odom.x;
-  double odom_dy = new_odom.y - old_odom.y;
-  double old_odom_theta = old_odom.theta;
-
-  double local_dx =
-    std::cos(old_odom_theta) * odom_dx + std::sin(old_odom_theta) * odom_dy;
-  double local_dy =
-    -std::sin(old_odom_theta) * odom_dx + std::cos(old_odom_theta) * odom_dy;
-  double local_dtheta = normalizeAngle(new_odom.theta - old_odom.theta);
-
-  Pose2D predicted = slam_pose_;
-  predicted.x += std::cos(slam_pose_.theta) * local_dx -
-    std::sin(slam_pose_.theta) * local_dy;
-  predicted.y += std::sin(slam_pose_.theta) * local_dx +
-    std::cos(slam_pose_.theta) * local_dy;
-  predicted.theta = normalizeAngle(slam_pose_.theta + local_dtheta);
-  return predicted;
+  return slam_pose_;
 }
 
-ScanMatchResult SimpleSlam::matchScan(
-  const sensor_msgs::msg::LaserScan & scan, const Pose2D & predicted)
+const Pose2D & SimpleSlam::currentOdomPose() const
 {
-  ScanMatchResult result;
-  result.pose = predicted;
-
-  if (!scan_received_) {
-    return result;
-  }
-
-  if (scans_integrated_ - last_scan_match_scan_index_ < min_scan_match_scan_gap_) {
-    return result;
-  }
-
-  if (occupied_cell_count_ < min_occupied_cells_for_matching_) {
-    return result;
-  }
-
-  if (scan_match_pose_initialized_) {
-    double distance_since_last_match = poseDistance(predicted, last_scan_match_pose_);
-    double rotation_since_last_match =
-      std::abs(normalizeAngle(predicted.theta - last_scan_match_pose_.theta));
-    if (distance_since_last_match < min_scan_match_translation_interval_ &&
-      rotation_since_last_match < min_scan_match_rotation_interval_)
-    {
-      return result;
-    }
-  }
-
-  if (likelihood_field_dirty_) {
-    rebuildLikelihoodField();
-    likelihood_field_dirty_ = false;
-  }
-
-  result.predicted_score = scoreScanAtPose(scan, predicted);
-
-  double best_score = -std::numeric_limits<double>::infinity();
-  Pose2D best_pose = predicted;
-
-  for (double dx = -scan_match_xy_range_; dx <= scan_match_xy_range_ + 1e-9;
-    dx += scan_match_xy_step_)
-  {
-    for (double dy = -scan_match_xy_range_; dy <= scan_match_xy_range_ + 1e-9;
-      dy += scan_match_xy_step_)
-    {
-      for (double dtheta = -scan_match_theta_range_;
-        dtheta <= scan_match_theta_range_ + 1e-9;
-        dtheta += scan_match_theta_step_)
-      {
-        Pose2D candidate;
-        candidate.x = predicted.x + dx;
-        candidate.y = predicted.y + dy;
-        candidate.theta = normalizeAngle(predicted.theta + dtheta);
-
-        double score = scoreScanAtPose(scan, candidate);
-        if (score > best_score) {
-          best_score = score;
-          best_pose = candidate;
-        }
-      }
-    }
-  }
-
-  result.score = std::max(best_score, 0.0);
-
-  double correction_translation = poseDistance(best_pose, predicted);
-  double correction_rotation =
-    std::abs(normalizeAngle(best_pose.theta - predicted.theta));
-  double score_improvement = result.score - result.predicted_score;
-
-  if (best_score >= min_scan_match_score_ &&
-    score_improvement >= min_scan_match_score_improvement_ &&
-    correction_translation <= max_scan_match_translation_correction_ &&
-    correction_rotation <= max_scan_match_rotation_correction_)
-  {
-    result.pose = best_pose;
-    result.used_scan_matching = true;
-    scan_match_used_count_++;
-    last_scan_match_scan_index_ = scans_integrated_;
-    last_scan_match_pose_ = result.pose;
-    scan_match_pose_initialized_ = true;
-  }
-
-  return result;
+  return current_odom_pose_;
 }
 
-void SimpleSlam::rebuildLikelihoodField()
+const nav_msgs::msg::OccupancyGrid & SimpleSlam::map() const
 {
-  likelihood_field_msg_ = map_msg_;
-  likelihood_field_msg_.data.assign(width_ * height_, 0);
-
-  int max_distance_cells = static_cast<int>(std::ceil(likelihood_max_distance_ / resolution_));
-  std::vector<int> distance_to_wall(width_ * height_, max_distance_cells + 1);
-  std::queue<int> cells_to_visit;
-
-  for (int row = 0; row < height_; ++row) {
-    for (int col = 0; col < width_; ++col) {
-      int index = row * width_ + col;
-      if (map_msg_.data[index] > 50) {
-        distance_to_wall[index] = 0;
-        cells_to_visit.push(index);
-      }
-    }
-  }
-
-  const int neighbor_offsets[4][2] = {
-    {1, 0},
-    {-1, 0},
-    {0, 1},
-    {0, -1}
-  };
-
-  while (!cells_to_visit.empty()) {
-    int index = cells_to_visit.front();
-    cells_to_visit.pop();
-
-    int row = index / width_;
-    int col = index % width_;
-    int next_distance = distance_to_wall[index] + 1;
-
-    if (next_distance > max_distance_cells) {
-      continue;
-    }
-
-    for (const auto & offset : neighbor_offsets) {
-      int next_col = col + offset[0];
-      int next_row = row + offset[1];
-
-      if (!isValidCell(next_col, next_row)) {
-        continue;
-      }
-
-      int next_index = next_row * width_ + next_col;
-      if (next_distance >= distance_to_wall[next_index]) {
-        continue;
-      }
-
-      distance_to_wall[next_index] = next_distance;
-      cells_to_visit.push(next_index);
-    }
-  }
-
-  for (int i = 0; i < width_ * height_; ++i) {
-    if (distance_to_wall[i] > max_distance_cells) {
-      continue;
-    }
-
-    double distance_m = distance_to_wall[i] * resolution_;
-    double likelihood = 1.0 - std::min(distance_m / likelihood_max_distance_, 1.0);
-    likelihood_field_msg_.data[i] = static_cast<int8_t>(std::round(likelihood * 100.0));
-  }
+  return mapper_.map();
 }
 
-double SimpleSlam::scoreScanAtPose(
-  const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose) const
+const nav_msgs::msg::OccupancyGrid & SimpleSlam::correctedMap() const
 {
-  double score = 0.0;
-  int used_beams = 0;
-
-  for (std::size_t i = 0; i < scan.ranges.size(); i += scan_match_beam_step_) {
-    float range = scan.ranges[i];
-
-    if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
-      continue;
-    }
-
-    double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
-    double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
-    double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
-
-    score += likelihoodAtWorld(hit_x, hit_y);
-    used_beams++;
-  }
-
-  if (used_beams == 0) {
-    return 0.0;
-  }
-
-  return score / used_beams;
+  return mapper_.correctedMap();
 }
 
-double SimpleSlam::likelihoodAtWorld(double x, double y) const
+const nav_msgs::msg::Path & SimpleSlam::trajectory() const
 {
-  int col = 0;
-  int row = 0;
-  worldToGrid(x, y, col, row);
-
-  if (!isValidCell(col, row)) {
-    return 0.0;
-  }
-
-  int index = row * width_ + col;
-  return likelihood_field_msg_.data[index] / 100.0;
+  return trajectory_msg_;
 }
 
-void SimpleSlam::updateMapWithScan(
-  const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose)
+const nav_msgs::msg::Path & SimpleSlam::correctedTrajectory() const
 {
-  insertScanIntoLogOddsMap(makeStoredScan(scan), pose, map_log_odds_);
+  return corrected_trajectory_msg_;
 }
 
-void SimpleSlam::insertScanIntoLogOddsMap(
-  const StoredScan & scan,
-  const Pose2D & pose,
-  std::vector<double> & log_odds_map)
+int SimpleSlam::scansIntegrated() const
 {
-  int robot_grid_x = 0;
-  int robot_grid_y = 0;
-  worldToGrid(pose.x, pose.y, robot_grid_x, robot_grid_y);
-
-  if (!isValidCell(robot_grid_x, robot_grid_y)) {
-    return;
-  }
-
-  for (std::size_t i = 0; i < scan.ranges.size(); ++i) {
-    float range = scan.ranges[i];
-
-    if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
-      continue;
-    }
-
-    double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
-    double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
-    double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
-
-    int hit_grid_x = 0;
-    int hit_grid_y = 0;
-    worldToGrid(hit_x, hit_y, hit_grid_x, hit_grid_y);
-
-    if (!isValidCell(hit_grid_x, hit_grid_y)) {
-      continue;
-    }
-
-    auto cells = bresenhamLine(robot_grid_x, robot_grid_y, hit_grid_x, hit_grid_y);
-    if (cells.empty()) {
-      continue;
-    }
-
-    for (std::size_t cell_index = 0; cell_index + 1 < cells.size(); ++cell_index) {
-      int x = cells[cell_index].first;
-      int y = cells[cell_index].second;
-      int index = y * width_ + x;
-      log_odds_map[index] =
-        clamp(log_odds_map[index] + log_odds_free_, log_odds_min_, log_odds_max_);
-    }
-
-    int hit_index = cells.back().second * width_ + cells.back().first;
-    log_odds_map[hit_index] =
-      clamp(log_odds_map[hit_index] + log_odds_hit_, log_odds_min_, log_odds_max_);
-  }
+  return scans_integrated_;
 }
 
-void SimpleSlam::rebuildCorrectedMap(const builtin_interfaces::msg::Time & stamp)
+int SimpleSlam::stationaryScansSkipped() const
 {
-  corrected_map_log_odds_.assign(width_ * height_, 0.0);
-
-  for (const auto & keyframe : keyframes_) {
-    insertScanIntoLogOddsMap(
-      keyframe.scan,
-      keyframe.corrected_pose,
-      corrected_map_log_odds_);
-  }
-
-  updateCorrectedMapMessage(stamp);
+  return stationary_scans_skipped_;
 }
 
-void SimpleSlam::updateMapMessage(const builtin_interfaces::msg::Time & stamp)
+int SimpleSlam::scanMatchUsedCount() const
 {
-  map_msg_.header.stamp = stamp;
-  occupied_cell_count_ = 0;
-
-  for (int i = 0; i < width_ * height_; ++i) {
-    double probability = 1.0 / (1.0 + std::exp(-map_log_odds_[i]));
-
-    if (map_log_odds_[i] == 0.0) {
-      map_msg_.data[i] = -1;
-    } else {
-      map_msg_.data[i] = static_cast<int8_t>(std::round(probability * 100.0));
-    }
-
-    if (map_msg_.data[i] > 50) {
-      occupied_cell_count_++;
-    }
-  }
+  return localization_.scanMatchUsedCount();
 }
 
-void SimpleSlam::updateCorrectedMapMessage(const builtin_interfaces::msg::Time & stamp)
+int SimpleSlam::loopClosureCount() const
 {
-  corrected_map_msg_.header.stamp = stamp;
+  return loop_closure_.loopClosureCount();
+}
 
-  for (int i = 0; i < width_ * height_; ++i) {
-    double probability = 1.0 / (1.0 + std::exp(-corrected_map_log_odds_[i]));
+int SimpleSlam::loopClosureCorrectionCount() const
+{
+  return loop_closure_.loopClosureCorrectionCount();
+}
 
-    if (corrected_map_log_odds_[i] == 0.0) {
-      corrected_map_msg_.data[i] = -1;
-    } else {
-      corrected_map_msg_.data[i] = static_cast<int8_t>(std::round(probability * 100.0));
-    }
-  }
+int SimpleSlam::occupiedCellCount() const
+{
+  return mapper_.occupiedCellCount();
+}
+
+std::size_t SimpleSlam::keyframeCount() const
+{
+  return loop_closure_.keyframeCount();
 }
 
 void SimpleSlam::updateTrajectory(const builtin_interfaces::msg::Time & stamp)
@@ -494,9 +185,9 @@ void SimpleSlam::updateCorrectedTrajectory(const builtin_interfaces::msg::Time &
 {
   corrected_trajectory_msg_.header.stamp = stamp;
   corrected_trajectory_msg_.poses.clear();
-  corrected_trajectory_msg_.poses.reserve(keyframes_.size());
+  corrected_trajectory_msg_.poses.reserve(loop_closure_.keyframes().size());
 
-  for (const auto & keyframe : keyframes_) {
+  for (const auto & keyframe : loop_closure_.keyframes()) {
     geometry_msgs::msg::PoseStamped pose;
     pose.header.stamp = stamp;
     pose.header.frame_id = "map";
@@ -507,218 +198,6 @@ void SimpleSlam::updateCorrectedTrajectory(const builtin_interfaces::msg::Time &
   }
 }
 
-bool SimpleSlam::shouldAddKeyFrame() const
-{
-  if (!keyframe_initialized_) {
-    return true;
-  }
-
-  double distance = poseDistance(slam_pose_, last_keyframe_pose_);
-  double rotation = std::abs(normalizeAngle(slam_pose_.theta - last_keyframe_pose_.theta));
-
-  return distance >= keyframe_min_translation_ || rotation >= keyframe_min_rotation_;
-}
-
-void SimpleSlam::addKeyFrame(const sensor_msgs::msg::LaserScan & scan)
-{
-  KeyFrame keyframe;
-  keyframe.pose = slam_pose_;
-  keyframe.corrected_pose = slam_pose_;
-  keyframe.scan_signature = makeScanSignature(scan);
-  keyframe.scan = makeStoredScan(scan);
-  keyframe.scan_index = scans_integrated_;
-
-  keyframes_.push_back(keyframe);
-  last_keyframe_pose_ = slam_pose_;
-  keyframe_initialized_ = true;
-}
-
-LoopClosureResult SimpleSlam::detectLoopClosure()
-{
-  if (keyframes_.size() <= static_cast<std::size_t>(min_loop_closure_keyframe_age_)) {
-    return {};
-  }
-
-  if (scans_integrated_ - last_loop_closure_scan_index_ < min_loop_closure_scan_gap_) {
-    return {};
-  }
-
-  std::size_t current_keyframe_index = keyframes_.size() - 1;
-  const KeyFrame & current_keyframe = keyframes_[current_keyframe_index];
-  double best_signature_difference = std::numeric_limits<double>::max();
-  std::size_t best_candidate_index = 0;
-  bool found_candidate = false;
-
-  for (std::size_t candidate_index = 0; candidate_index < current_keyframe_index;
-    ++candidate_index)
-  {
-    const KeyFrame & keyframe = keyframes_[candidate_index];
-    int keyframe_age = current_keyframe.scan_index - keyframe.scan_index;
-    if (keyframe_age < min_loop_closure_keyframe_age_) {
-      continue;
-    }
-
-    double distance = poseDistance(current_keyframe.pose, keyframe.pose);
-    if (distance > loop_closure_search_radius_) {
-      continue;
-    }
-
-    double heading_difference =
-      std::abs(normalizeAngle(current_keyframe.pose.theta - keyframe.pose.theta));
-    if (heading_difference > loop_closure_max_heading_diff_) {
-      continue;
-    }
-
-    double signature_difference =
-      scanSignatureDifference(current_keyframe.scan_signature, keyframe.scan_signature);
-    if (signature_difference < best_signature_difference) {
-      best_signature_difference = signature_difference;
-      best_candidate_index = candidate_index;
-      found_candidate = true;
-    }
-  }
-
-  if (!found_candidate || best_signature_difference > loop_closure_max_signature_diff_) {
-    return {};
-  }
-
-  loop_closure_count_++;
-  last_loop_closure_scan_index_ = scans_integrated_;
-  const KeyFrame & matched_keyframe = keyframes_[best_candidate_index];
-
-  LoopClosureResult result;
-  result.detected = true;
-  result.matched_pose = matched_keyframe.pose;
-  result.current_keyframe_index = current_keyframe_index;
-  result.matched_keyframe_index = best_candidate_index;
-  result.matched_scan_index = matched_keyframe.scan_index;
-  result.signature_difference = best_signature_difference;
-
-  if (shouldApplyLoopClosureCorrection(best_candidate_index, current_keyframe_index)) {
-    applyLoopClosureCorrection(best_candidate_index, current_keyframe_index);
-    result.correction_applied = true;
-  }
-
-  return result;
-}
-
-bool SimpleSlam::shouldApplyLoopClosureCorrection(
-  std::size_t matched_keyframe_index, std::size_t current_keyframe_index) const
-{
-  if (current_keyframe_index <= matched_keyframe_index) {
-    return false;
-  }
-
-  if (current_keyframe_index - matched_keyframe_index < min_correction_keyframe_gap_) {
-    return false;
-  }
-
-  if (scans_integrated_ - last_correction_scan_index_ < min_correction_scan_gap_) {
-    return false;
-  }
-
-  if (last_corrected_matched_keyframe_index_ != std::numeric_limits<std::size_t>::max()) {
-    std::size_t separation =
-      matched_keyframe_index > last_corrected_matched_keyframe_index_ ?
-      matched_keyframe_index - last_corrected_matched_keyframe_index_ :
-      last_corrected_matched_keyframe_index_ - matched_keyframe_index;
-
-    if (separation < min_old_keyframe_separation_for_correction_) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-void SimpleSlam::applyLoopClosureCorrection(
-  std::size_t matched_keyframe_index, std::size_t current_keyframe_index)
-{
-  if (current_keyframe_index <= matched_keyframe_index ||
-    current_keyframe_index >= keyframes_.size())
-  {
-    return;
-  }
-
-  const Pose2D matched_pose = keyframes_[matched_keyframe_index].corrected_pose;
-  const Pose2D current_pose = keyframes_[current_keyframe_index].corrected_pose;
-
-  double error_x = loop_closure_correction_strength_ * (matched_pose.x - current_pose.x);
-  double error_y = loop_closure_correction_strength_ * (matched_pose.y - current_pose.y);
-  double error_theta =
-    loop_closure_correction_strength_ * normalizeAngle(matched_pose.theta - current_pose.theta);
-  double span = static_cast<double>(current_keyframe_index - matched_keyframe_index);
-
-  for (std::size_t keyframe_index = matched_keyframe_index + 1;
-    keyframe_index <= current_keyframe_index;
-    ++keyframe_index)
-  {
-    double fraction = static_cast<double>(keyframe_index - matched_keyframe_index) / span;
-    keyframes_[keyframe_index].corrected_pose.x += fraction * error_x;
-    keyframes_[keyframe_index].corrected_pose.y += fraction * error_y;
-    keyframes_[keyframe_index].corrected_pose.theta =
-      normalizeAngle(keyframes_[keyframe_index].corrected_pose.theta + fraction * error_theta);
-  }
-
-  loop_closure_correction_count_++;
-  last_correction_scan_index_ = scans_integrated_;
-  last_corrected_matched_keyframe_index_ = matched_keyframe_index;
-}
-
-StoredScan SimpleSlam::makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const
-{
-  StoredScan stored_scan;
-  stored_scan.ranges = scan.ranges;
-  stored_scan.angle_min = scan.angle_min;
-  stored_scan.angle_increment = scan.angle_increment;
-  stored_scan.range_min = scan.range_min;
-  stored_scan.range_max = scan.range_max;
-  return stored_scan;
-}
-
-std::vector<float> SimpleSlam::makeScanSignature(
-  const sensor_msgs::msg::LaserScan & scan) const
-{
-  std::vector<float> signature;
-  signature.reserve(scan.ranges.size() / scan_signature_beam_step_ + 1);
-
-  for (std::size_t i = 0; i < scan.ranges.size(); i += scan_signature_beam_step_) {
-    float range = scan.ranges[i];
-    if (!std::isfinite(range) || range < scan.range_min) {
-      range = scan.range_max;
-    }
-
-    range = std::min(range, scan.range_max);
-    signature.push_back(range / scan.range_max);
-  }
-
-  return signature;
-}
-
-double SimpleSlam::scanSignatureDifference(
-  const std::vector<float> & first,
-  const std::vector<float> & second) const
-{
-  std::size_t count = std::min(first.size(), second.size());
-  if (count == 0) {
-    return std::numeric_limits<double>::max();
-  }
-
-  double difference_sum = 0.0;
-  for (std::size_t i = 0; i < count; ++i) {
-    difference_sum += std::abs(first[i] - second[i]);
-  }
-
-  return difference_sum / count;
-}
-
-double SimpleSlam::poseDistance(const Pose2D & first, const Pose2D & second) const
-{
-  double dx = first.x - second.x;
-  double dy = first.y - second.y;
-  return std::sqrt(dx * dx + dy * dy);
-}
-
 Pose2D SimpleSlam::odomMsgToPose(const nav_msgs::msg::Odometry & msg) const
 {
   Pose2D pose;
@@ -726,6 +205,29 @@ Pose2D SimpleSlam::odomMsgToPose(const nav_msgs::msg::Odometry & msg) const
   pose.y = msg.pose.pose.position.y;
   pose.theta = tf2::getYaw(msg.pose.pose.orientation);
   return pose;
+}
+
+Pose2D SimpleSlam::applyOdomDeltaToSlamPose(
+  const Pose2D & old_odom,
+  const Pose2D & new_odom) const
+{
+  double odom_dx = new_odom.x - old_odom.x;
+  double odom_dy = new_odom.y - old_odom.y;
+  double old_odom_theta = old_odom.theta;
+
+  double local_dx =
+    std::cos(old_odom_theta) * odom_dx + std::sin(old_odom_theta) * odom_dy;
+  double local_dy =
+    -std::sin(old_odom_theta) * odom_dx + std::cos(old_odom_theta) * odom_dy;
+  double local_dtheta = normalizeAngle(new_odom.theta - old_odom.theta);
+
+  Pose2D predicted = slam_pose_;
+  predicted.x += std::cos(slam_pose_.theta) * local_dx -
+    std::sin(slam_pose_.theta) * local_dy;
+  predicted.y += std::sin(slam_pose_.theta) * local_dx +
+    std::cos(slam_pose_.theta) * local_dy;
+  predicted.theta = normalizeAngle(slam_pose_.theta + local_dtheta);
+  return predicted;
 }
 
 bool SimpleSlam::odomMovedEnough(const Pose2D & old_odom, const Pose2D & new_odom) const
@@ -751,52 +253,6 @@ geometry_msgs::msg::Quaternion SimpleSlam::yawToQuaternion(double yaw) const
   return msg;
 }
 
-void SimpleSlam::worldToGrid(double wx, double wy, int & gx, int & gy) const
-{
-  gx = static_cast<int>(std::floor((wx - origin_x_) / resolution_));
-  gy = static_cast<int>(std::floor((wy - origin_y_) / resolution_));
-}
-
-bool SimpleSlam::isValidCell(int x, int y) const
-{
-  return x >= 0 && x < width_ && y >= 0 && y < height_;
-}
-
-std::vector<std::pair<int, int>> SimpleSlam::bresenhamLine(
-  int x0, int y0, int x1, int y1) const
-{
-  std::vector<std::pair<int, int>> cells;
-
-  int dx = std::abs(x1 - x0);
-  int dy = std::abs(y1 - y0);
-  int sx = x0 < x1 ? 1 : -1;
-  int sy = y0 < y1 ? 1 : -1;
-  int err = dx - dy;
-
-  int x = x0;
-  int y = y0;
-
-  while (true) {
-    cells.push_back({x, y});
-
-    if (x == x1 && y == y1) {
-      break;
-    }
-
-    int e2 = 2 * err;
-    if (e2 > -dy) {
-      err -= dy;
-      x += sx;
-    }
-    if (e2 < dx) {
-      err += dx;
-      y += sy;
-    }
-  }
-
-  return cells;
-}
-
 double SimpleSlam::normalizeAngle(double angle) const
 {
   while (angle > M_PI) {
@@ -806,82 +262,6 @@ double SimpleSlam::normalizeAngle(double angle) const
     angle += 2.0 * M_PI;
   }
   return angle;
-}
-
-double SimpleSlam::clamp(double value, double low, double high) const
-{
-  return std::min(std::max(value, low), high);
-}
-
-
-bool SimpleSlam::hasOdometry() const
-{
-  return odom_initialized_;
-}
-
-const Pose2D & SimpleSlam::slamPose() const
-{
-  return slam_pose_;
-}
-
-const Pose2D & SimpleSlam::currentOdomPose() const
-{
-  return current_odom_pose_;
-}
-
-const nav_msgs::msg::OccupancyGrid & SimpleSlam::map() const
-{
-  return map_msg_;
-}
-
-const nav_msgs::msg::OccupancyGrid & SimpleSlam::correctedMap() const
-{
-  return corrected_map_msg_;
-}
-
-const nav_msgs::msg::Path & SimpleSlam::trajectory() const
-{
-  return trajectory_msg_;
-}
-
-const nav_msgs::msg::Path & SimpleSlam::correctedTrajectory() const
-{
-  return corrected_trajectory_msg_;
-}
-
-int SimpleSlam::scansIntegrated() const
-{
-  return scans_integrated_;
-}
-
-int SimpleSlam::stationaryScansSkipped() const
-{
-  return stationary_scans_skipped_;
-}
-
-int SimpleSlam::scanMatchUsedCount() const
-{
-  return scan_match_used_count_;
-}
-
-int SimpleSlam::loopClosureCount() const
-{
-  return loop_closure_count_;
-}
-
-int SimpleSlam::loopClosureCorrectionCount() const
-{
-  return loop_closure_correction_count_;
-}
-
-int SimpleSlam::occupiedCellCount() const
-{
-  return occupied_cell_count_;
-}
-
-std::size_t SimpleSlam::keyframeCount() const
-{
-  return keyframes_.size();
 }
 
 }  // namespace slam

--- a/src/slam/src/simple_slam.cpp
+++ b/src/slam/src/simple_slam.cpp
@@ -14,6 +14,56 @@ namespace slam
 
 SimpleSlam::SimpleSlam()
 {
+  configure(SimpleSlamConfig());
+}
+
+void SimpleSlam::configure(const SimpleSlamConfig & config)
+{
+  config_ = config;
+
+  resolution_ = config_.resolution;
+  width_ = config_.width;
+  height_ = config_.height;
+  origin_x_ = config_.origin_x;
+  origin_y_ = config_.origin_y;
+
+  log_odds_hit_ = config_.log_odds_hit;
+  log_odds_free_ = config_.log_odds_free;
+  log_odds_min_ = config_.log_odds_min;
+  log_odds_max_ = config_.log_odds_max;
+
+  min_occupied_cells_for_matching_ = config_.min_occupied_cells_for_matching;
+  likelihood_max_distance_ = config_.likelihood_max_distance;
+
+  scan_match_xy_range_ = config_.scan_match_xy_range;
+  scan_match_xy_step_ = config_.scan_match_xy_step;
+  scan_match_theta_range_ = config_.scan_match_theta_range;
+  scan_match_theta_step_ = config_.scan_match_theta_step;
+  scan_match_beam_step_ = config_.scan_match_beam_step;
+  min_scan_match_score_ = config_.min_scan_match_score;
+  min_scan_match_score_improvement_ = config_.min_scan_match_score_improvement;
+  max_scan_match_translation_correction_ = config_.max_scan_match_translation_correction;
+  max_scan_match_rotation_correction_ = config_.max_scan_match_rotation_correction;
+  min_scan_match_translation_interval_ = config_.min_scan_match_translation_interval;
+  min_scan_match_rotation_interval_ = config_.min_scan_match_rotation_interval;
+  min_scan_match_scan_gap_ = config_.min_scan_match_scan_gap;
+  min_update_translation_ = config_.min_update_translation;
+  min_update_rotation_ = config_.min_update_rotation;
+
+  keyframe_min_translation_ = config_.keyframe_min_translation;
+  keyframe_min_rotation_ = config_.keyframe_min_rotation;
+  scan_signature_beam_step_ = config_.scan_signature_beam_step;
+  min_loop_closure_keyframe_age_ = config_.min_loop_closure_keyframe_age;
+  loop_closure_search_radius_ = config_.loop_closure_search_radius;
+  loop_closure_max_heading_diff_ = config_.loop_closure_max_heading_diff;
+  loop_closure_max_signature_diff_ = config_.loop_closure_max_signature_diff;
+  min_loop_closure_scan_gap_ = config_.min_loop_closure_scan_gap;
+  min_correction_scan_gap_ = config_.min_correction_scan_gap;
+  min_correction_keyframe_gap_ = config_.min_correction_keyframe_gap;
+  min_old_keyframe_separation_for_correction_ =
+    config_.min_old_keyframe_separation_for_correction;
+  loop_closure_correction_strength_ = config_.loop_closure_correction_strength;
+
   initializeMap();
 }
 
@@ -84,9 +134,6 @@ SlamUpdateResult SimpleSlam::handleScan(
 
 void SimpleSlam::initializeMap()
 {
-  origin_x_ = -width_ * resolution_ / 2.0;
-  origin_y_ = -height_ * resolution_ / 2.0;
-
   map_log_odds_.assign(width_ * height_, 0.0);
   corrected_map_log_odds_.assign(width_ * height_, 0.0);
 
@@ -139,7 +186,7 @@ ScanMatchResult SimpleSlam::matchScan(
     return result;
   }
 
-  if (scans_integrated_ - last_scan_match_scan_ < min_scan_match_scan_gap_) {
+  if (scans_integrated_ - last_scan_match_scan_index_ < min_scan_match_scan_gap_) {
     return result;
   }
 
@@ -168,11 +215,15 @@ ScanMatchResult SimpleSlam::matchScan(
   double best_score = -std::numeric_limits<double>::infinity();
   Pose2D best_pose = predicted;
 
-  for (double dx = -search_xy_range_; dx <= search_xy_range_ + 1e-9; dx += search_xy_step_) {
-    for (double dy = -search_xy_range_; dy <= search_xy_range_ + 1e-9; dy += search_xy_step_) {
-      for (double dtheta = -search_theta_range_;
-        dtheta <= search_theta_range_ + 1e-9;
-        dtheta += search_theta_step_)
+  for (double dx = -scan_match_xy_range_; dx <= scan_match_xy_range_ + 1e-9;
+    dx += scan_match_xy_step_)
+  {
+    for (double dy = -scan_match_xy_range_; dy <= scan_match_xy_range_ + 1e-9;
+      dy += scan_match_xy_step_)
+    {
+      for (double dtheta = -scan_match_theta_range_;
+        dtheta <= scan_match_theta_range_ + 1e-9;
+        dtheta += scan_match_theta_step_)
       {
         Pose2D candidate;
         candidate.x = predicted.x + dx;
@@ -203,7 +254,7 @@ ScanMatchResult SimpleSlam::matchScan(
     result.pose = best_pose;
     result.used_scan_matching = true;
     scan_match_used_count_++;
-    last_scan_match_scan_ = scans_integrated_;
+    last_scan_match_scan_index_ = scans_integrated_;
     last_scan_match_pose_ = result.pose;
     scan_match_pose_initialized_ = true;
   }
@@ -488,18 +539,20 @@ LoopClosureResult SimpleSlam::detectLoopClosure()
     return {};
   }
 
-  if (scans_integrated_ - last_loop_closure_scan_ < min_loop_closure_scan_gap_) {
+  if (scans_integrated_ - last_loop_closure_scan_index_ < min_loop_closure_scan_gap_) {
     return {};
   }
 
-  std::size_t current_index = keyframes_.size() - 1;
-  const KeyFrame & current_keyframe = keyframes_[current_index];
-  double best_difference = std::numeric_limits<double>::max();
-  std::size_t best_index = 0;
+  std::size_t current_keyframe_index = keyframes_.size() - 1;
+  const KeyFrame & current_keyframe = keyframes_[current_keyframe_index];
+  double best_signature_difference = std::numeric_limits<double>::max();
+  std::size_t best_candidate_index = 0;
   bool found_candidate = false;
 
-  for (std::size_t i = 0; i < current_index; ++i) {
-    const KeyFrame & keyframe = keyframes_[i];
+  for (std::size_t candidate_index = 0; candidate_index < current_keyframe_index;
+    ++candidate_index)
+  {
+    const KeyFrame & keyframe = keyframes_[candidate_index];
     int keyframe_age = current_keyframe.scan_index - keyframe.scan_index;
     if (keyframe_age < min_loop_closure_keyframe_age_) {
       continue;
@@ -518,31 +571,31 @@ LoopClosureResult SimpleSlam::detectLoopClosure()
 
     double signature_difference =
       scanSignatureDifference(current_keyframe.scan_signature, keyframe.scan_signature);
-    if (signature_difference < best_difference) {
-      best_difference = signature_difference;
-      best_index = i;
+    if (signature_difference < best_signature_difference) {
+      best_signature_difference = signature_difference;
+      best_candidate_index = candidate_index;
       found_candidate = true;
     }
   }
 
-  if (!found_candidate || best_difference > loop_closure_max_signature_diff_) {
+  if (!found_candidate || best_signature_difference > loop_closure_max_signature_diff_) {
     return {};
   }
 
   loop_closure_count_++;
-  last_loop_closure_scan_ = scans_integrated_;
-  const KeyFrame & matched_keyframe = keyframes_[best_index];
+  last_loop_closure_scan_index_ = scans_integrated_;
+  const KeyFrame & matched_keyframe = keyframes_[best_candidate_index];
 
   LoopClosureResult result;
   result.detected = true;
   result.matched_pose = matched_keyframe.pose;
-  result.current_keyframe_index = current_index;
-  result.matched_keyframe_index = best_index;
+  result.current_keyframe_index = current_keyframe_index;
+  result.matched_keyframe_index = best_candidate_index;
   result.matched_scan_index = matched_keyframe.scan_index;
-  result.signature_difference = best_difference;
+  result.signature_difference = best_signature_difference;
 
-  if (shouldApplyLoopClosureCorrection(best_index, current_index)) {
-    applyLoopClosureCorrection(best_index, current_index);
+  if (shouldApplyLoopClosureCorrection(best_candidate_index, current_keyframe_index)) {
+    applyLoopClosureCorrection(best_candidate_index, current_keyframe_index);
     result.correction_applied = true;
   }
 
@@ -550,25 +603,25 @@ LoopClosureResult SimpleSlam::detectLoopClosure()
 }
 
 bool SimpleSlam::shouldApplyLoopClosureCorrection(
-  std::size_t old_index, std::size_t current_index) const
+  std::size_t matched_keyframe_index, std::size_t current_keyframe_index) const
 {
-  if (current_index <= old_index) {
+  if (current_keyframe_index <= matched_keyframe_index) {
     return false;
   }
 
-  if (current_index - old_index < min_correction_keyframe_gap_) {
+  if (current_keyframe_index - matched_keyframe_index < min_correction_keyframe_gap_) {
     return false;
   }
 
-  if (scans_integrated_ - last_correction_scan_ < min_correction_scan_gap_) {
+  if (scans_integrated_ - last_correction_scan_index_ < min_correction_scan_gap_) {
     return false;
   }
 
-  if (last_corrected_old_keyframe_ != std::numeric_limits<std::size_t>::max()) {
+  if (last_corrected_matched_keyframe_index_ != std::numeric_limits<std::size_t>::max()) {
     std::size_t separation =
-      old_index > last_corrected_old_keyframe_ ?
-      old_index - last_corrected_old_keyframe_ :
-      last_corrected_old_keyframe_ - old_index;
+      matched_keyframe_index > last_corrected_matched_keyframe_index_ ?
+      matched_keyframe_index - last_corrected_matched_keyframe_index_ :
+      last_corrected_matched_keyframe_index_ - matched_keyframe_index;
 
     if (separation < min_old_keyframe_separation_for_correction_) {
       return false;
@@ -579,32 +632,37 @@ bool SimpleSlam::shouldApplyLoopClosureCorrection(
 }
 
 void SimpleSlam::applyLoopClosureCorrection(
-  std::size_t old_index, std::size_t current_index)
+  std::size_t matched_keyframe_index, std::size_t current_keyframe_index)
 {
-  if (current_index <= old_index || current_index >= keyframes_.size()) {
+  if (current_keyframe_index <= matched_keyframe_index ||
+    current_keyframe_index >= keyframes_.size())
+  {
     return;
   }
 
-  const Pose2D old_pose = keyframes_[old_index].corrected_pose;
-  const Pose2D current_pose = keyframes_[current_index].corrected_pose;
+  const Pose2D matched_pose = keyframes_[matched_keyframe_index].corrected_pose;
+  const Pose2D current_pose = keyframes_[current_keyframe_index].corrected_pose;
 
-  double error_x = loop_closure_correction_strength_ * (old_pose.x - current_pose.x);
-  double error_y = loop_closure_correction_strength_ * (old_pose.y - current_pose.y);
+  double error_x = loop_closure_correction_strength_ * (matched_pose.x - current_pose.x);
+  double error_y = loop_closure_correction_strength_ * (matched_pose.y - current_pose.y);
   double error_theta =
-    loop_closure_correction_strength_ * normalizeAngle(old_pose.theta - current_pose.theta);
-  double span = static_cast<double>(current_index - old_index);
+    loop_closure_correction_strength_ * normalizeAngle(matched_pose.theta - current_pose.theta);
+  double span = static_cast<double>(current_keyframe_index - matched_keyframe_index);
 
-  for (std::size_t i = old_index + 1; i <= current_index; ++i) {
-    double fraction = static_cast<double>(i - old_index) / span;
-    keyframes_[i].corrected_pose.x += fraction * error_x;
-    keyframes_[i].corrected_pose.y += fraction * error_y;
-    keyframes_[i].corrected_pose.theta =
-      normalizeAngle(keyframes_[i].corrected_pose.theta + fraction * error_theta);
+  for (std::size_t keyframe_index = matched_keyframe_index + 1;
+    keyframe_index <= current_keyframe_index;
+    ++keyframe_index)
+  {
+    double fraction = static_cast<double>(keyframe_index - matched_keyframe_index) / span;
+    keyframes_[keyframe_index].corrected_pose.x += fraction * error_x;
+    keyframes_[keyframe_index].corrected_pose.y += fraction * error_y;
+    keyframes_[keyframe_index].corrected_pose.theta =
+      normalizeAngle(keyframes_[keyframe_index].corrected_pose.theta + fraction * error_theta);
   }
 
   loop_closure_correction_count_++;
-  last_correction_scan_ = scans_integrated_;
-  last_corrected_old_keyframe_ = old_index;
+  last_correction_scan_index_ = scans_integrated_;
+  last_corrected_matched_keyframe_index_ = matched_keyframe_index;
 }
 
 StoredScan SimpleSlam::makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const

--- a/src/slam/src/simple_slam.cpp
+++ b/src/slam/src/simple_slam.cpp
@@ -1,0 +1,829 @@
+#include "slam/simple_slam.hpp"
+
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2/utils.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <queue>
+
+namespace slam
+{
+
+SimpleSlam::SimpleSlam()
+{
+  initializeMap();
+}
+
+bool SimpleSlam::handleOdometry(const nav_msgs::msg::Odometry & msg)
+{
+  current_odom_pose_ = odomMsgToPose(msg);
+
+  if (!odom_initialized_) {
+    last_odom_pose_ = current_odom_pose_;
+    odom_initialized_ = true;
+    return true;
+  }
+
+  return false;
+}
+
+SlamUpdateResult SimpleSlam::handleScan(
+  const sensor_msgs::msg::LaserScan & scan,
+  const builtin_interfaces::msg::Time & stamp)
+{
+  SlamUpdateResult update;
+
+  if (!odom_initialized_) {
+    return update;
+  }
+
+  bool moved_enough = odomMovedEnough(last_odom_pose_, current_odom_pose_);
+  Pose2D predicted_pose = applyOdomDeltaToSlamPose(last_odom_pose_, current_odom_pose_);
+  last_odom_pose_ = current_odom_pose_;
+
+  if (scan_received_ && !moved_enough) {
+    stationary_scans_skipped_++;
+    update.stationary_scan_skipped = true;
+    return update;
+  }
+
+  update.scan_match = matchScan(scan, predicted_pose);
+  slam_pose_ = update.scan_match.pose;
+
+  updateMapWithScan(scan, slam_pose_);
+  updateMapMessage(stamp);
+
+  scan_received_ = true;
+  scans_integrated_++;
+  likelihood_field_dirty_ = true;
+  updateTrajectory(stamp);
+
+  update.scan_integrated = true;
+  update.map_updated = true;
+  update.trajectory_updated = true;
+
+  if (shouldAddKeyFrame()) {
+    addKeyFrame(scan);
+    update.keyframe_added = true;
+    update.loop_closure = detectLoopClosure();
+    if (update.loop_closure.correction_applied) {
+      updateCorrectedTrajectory(stamp);
+      rebuildCorrectedMap(stamp);
+      update.corrected_map_updated = true;
+    }
+  }
+
+  updateCorrectedTrajectory(stamp);
+  update.corrected_trajectory_updated = true;
+
+  return update;
+}
+
+void SimpleSlam::initializeMap()
+{
+  origin_x_ = -width_ * resolution_ / 2.0;
+  origin_y_ = -height_ * resolution_ / 2.0;
+
+  map_log_odds_.assign(width_ * height_, 0.0);
+  corrected_map_log_odds_.assign(width_ * height_, 0.0);
+
+  map_msg_.header.frame_id = "map";
+  map_msg_.info.resolution = resolution_;
+  map_msg_.info.width = width_;
+  map_msg_.info.height = height_;
+  map_msg_.info.origin.position.x = origin_x_;
+  map_msg_.info.origin.position.y = origin_y_;
+  map_msg_.info.origin.orientation.w = 1.0;
+  map_msg_.data.assign(width_ * height_, -1);
+  corrected_map_msg_ = map_msg_;
+
+  likelihood_field_msg_ = map_msg_;
+  likelihood_field_msg_.data.assign(width_ * height_, 0);
+
+  trajectory_msg_.header.frame_id = "map";
+  corrected_trajectory_msg_.header.frame_id = "map";
+}
+
+Pose2D SimpleSlam::applyOdomDeltaToSlamPose(
+  const Pose2D & old_odom, const Pose2D & new_odom) const
+{
+  double odom_dx = new_odom.x - old_odom.x;
+  double odom_dy = new_odom.y - old_odom.y;
+  double old_odom_theta = old_odom.theta;
+
+  double local_dx =
+    std::cos(old_odom_theta) * odom_dx + std::sin(old_odom_theta) * odom_dy;
+  double local_dy =
+    -std::sin(old_odom_theta) * odom_dx + std::cos(old_odom_theta) * odom_dy;
+  double local_dtheta = normalizeAngle(new_odom.theta - old_odom.theta);
+
+  Pose2D predicted = slam_pose_;
+  predicted.x += std::cos(slam_pose_.theta) * local_dx -
+    std::sin(slam_pose_.theta) * local_dy;
+  predicted.y += std::sin(slam_pose_.theta) * local_dx +
+    std::cos(slam_pose_.theta) * local_dy;
+  predicted.theta = normalizeAngle(slam_pose_.theta + local_dtheta);
+  return predicted;
+}
+
+ScanMatchResult SimpleSlam::matchScan(
+  const sensor_msgs::msg::LaserScan & scan, const Pose2D & predicted)
+{
+  ScanMatchResult result;
+  result.pose = predicted;
+
+  if (!scan_received_) {
+    return result;
+  }
+
+  if (scans_integrated_ - last_scan_match_scan_ < min_scan_match_scan_gap_) {
+    return result;
+  }
+
+  if (occupied_cell_count_ < min_occupied_cells_for_matching_) {
+    return result;
+  }
+
+  if (scan_match_pose_initialized_) {
+    double distance_since_last_match = poseDistance(predicted, last_scan_match_pose_);
+    double rotation_since_last_match =
+      std::abs(normalizeAngle(predicted.theta - last_scan_match_pose_.theta));
+    if (distance_since_last_match < min_scan_match_translation_interval_ &&
+      rotation_since_last_match < min_scan_match_rotation_interval_)
+    {
+      return result;
+    }
+  }
+
+  if (likelihood_field_dirty_) {
+    rebuildLikelihoodField();
+    likelihood_field_dirty_ = false;
+  }
+
+  result.predicted_score = scoreScanAtPose(scan, predicted);
+
+  double best_score = -std::numeric_limits<double>::infinity();
+  Pose2D best_pose = predicted;
+
+  for (double dx = -search_xy_range_; dx <= search_xy_range_ + 1e-9; dx += search_xy_step_) {
+    for (double dy = -search_xy_range_; dy <= search_xy_range_ + 1e-9; dy += search_xy_step_) {
+      for (double dtheta = -search_theta_range_;
+        dtheta <= search_theta_range_ + 1e-9;
+        dtheta += search_theta_step_)
+      {
+        Pose2D candidate;
+        candidate.x = predicted.x + dx;
+        candidate.y = predicted.y + dy;
+        candidate.theta = normalizeAngle(predicted.theta + dtheta);
+
+        double score = scoreScanAtPose(scan, candidate);
+        if (score > best_score) {
+          best_score = score;
+          best_pose = candidate;
+        }
+      }
+    }
+  }
+
+  result.score = std::max(best_score, 0.0);
+
+  double correction_translation = poseDistance(best_pose, predicted);
+  double correction_rotation =
+    std::abs(normalizeAngle(best_pose.theta - predicted.theta));
+  double score_improvement = result.score - result.predicted_score;
+
+  if (best_score >= min_scan_match_score_ &&
+    score_improvement >= min_scan_match_score_improvement_ &&
+    correction_translation <= max_scan_match_translation_correction_ &&
+    correction_rotation <= max_scan_match_rotation_correction_)
+  {
+    result.pose = best_pose;
+    result.used_scan_matching = true;
+    scan_match_used_count_++;
+    last_scan_match_scan_ = scans_integrated_;
+    last_scan_match_pose_ = result.pose;
+    scan_match_pose_initialized_ = true;
+  }
+
+  return result;
+}
+
+void SimpleSlam::rebuildLikelihoodField()
+{
+  likelihood_field_msg_ = map_msg_;
+  likelihood_field_msg_.data.assign(width_ * height_, 0);
+
+  int max_distance_cells = static_cast<int>(std::ceil(likelihood_max_distance_ / resolution_));
+  std::vector<int> distance_to_wall(width_ * height_, max_distance_cells + 1);
+  std::queue<int> cells_to_visit;
+
+  for (int row = 0; row < height_; ++row) {
+    for (int col = 0; col < width_; ++col) {
+      int index = row * width_ + col;
+      if (map_msg_.data[index] > 50) {
+        distance_to_wall[index] = 0;
+        cells_to_visit.push(index);
+      }
+    }
+  }
+
+  const int neighbor_offsets[4][2] = {
+    {1, 0},
+    {-1, 0},
+    {0, 1},
+    {0, -1}
+  };
+
+  while (!cells_to_visit.empty()) {
+    int index = cells_to_visit.front();
+    cells_to_visit.pop();
+
+    int row = index / width_;
+    int col = index % width_;
+    int next_distance = distance_to_wall[index] + 1;
+
+    if (next_distance > max_distance_cells) {
+      continue;
+    }
+
+    for (const auto & offset : neighbor_offsets) {
+      int next_col = col + offset[0];
+      int next_row = row + offset[1];
+
+      if (!isValidCell(next_col, next_row)) {
+        continue;
+      }
+
+      int next_index = next_row * width_ + next_col;
+      if (next_distance >= distance_to_wall[next_index]) {
+        continue;
+      }
+
+      distance_to_wall[next_index] = next_distance;
+      cells_to_visit.push(next_index);
+    }
+  }
+
+  for (int i = 0; i < width_ * height_; ++i) {
+    if (distance_to_wall[i] > max_distance_cells) {
+      continue;
+    }
+
+    double distance_m = distance_to_wall[i] * resolution_;
+    double likelihood = 1.0 - std::min(distance_m / likelihood_max_distance_, 1.0);
+    likelihood_field_msg_.data[i] = static_cast<int8_t>(std::round(likelihood * 100.0));
+  }
+}
+
+double SimpleSlam::scoreScanAtPose(
+  const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose) const
+{
+  double score = 0.0;
+  int used_beams = 0;
+
+  for (std::size_t i = 0; i < scan.ranges.size(); i += scan_match_beam_step_) {
+    float range = scan.ranges[i];
+
+    if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
+      continue;
+    }
+
+    double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
+    double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
+    double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
+
+    score += likelihoodAtWorld(hit_x, hit_y);
+    used_beams++;
+  }
+
+  if (used_beams == 0) {
+    return 0.0;
+  }
+
+  return score / used_beams;
+}
+
+double SimpleSlam::likelihoodAtWorld(double x, double y) const
+{
+  int col = 0;
+  int row = 0;
+  worldToGrid(x, y, col, row);
+
+  if (!isValidCell(col, row)) {
+    return 0.0;
+  }
+
+  int index = row * width_ + col;
+  return likelihood_field_msg_.data[index] / 100.0;
+}
+
+void SimpleSlam::updateMapWithScan(
+  const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose)
+{
+  insertScanIntoLogOddsMap(makeStoredScan(scan), pose, map_log_odds_);
+}
+
+void SimpleSlam::insertScanIntoLogOddsMap(
+  const StoredScan & scan,
+  const Pose2D & pose,
+  std::vector<double> & log_odds_map)
+{
+  int robot_grid_x = 0;
+  int robot_grid_y = 0;
+  worldToGrid(pose.x, pose.y, robot_grid_x, robot_grid_y);
+
+  if (!isValidCell(robot_grid_x, robot_grid_y)) {
+    return;
+  }
+
+  for (std::size_t i = 0; i < scan.ranges.size(); ++i) {
+    float range = scan.ranges[i];
+
+    if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
+      continue;
+    }
+
+    double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
+    double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
+    double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
+
+    int hit_grid_x = 0;
+    int hit_grid_y = 0;
+    worldToGrid(hit_x, hit_y, hit_grid_x, hit_grid_y);
+
+    if (!isValidCell(hit_grid_x, hit_grid_y)) {
+      continue;
+    }
+
+    auto cells = bresenhamLine(robot_grid_x, robot_grid_y, hit_grid_x, hit_grid_y);
+    if (cells.empty()) {
+      continue;
+    }
+
+    for (std::size_t cell_index = 0; cell_index + 1 < cells.size(); ++cell_index) {
+      int x = cells[cell_index].first;
+      int y = cells[cell_index].second;
+      int index = y * width_ + x;
+      log_odds_map[index] =
+        clamp(log_odds_map[index] + log_odds_free_, log_odds_min_, log_odds_max_);
+    }
+
+    int hit_index = cells.back().second * width_ + cells.back().first;
+    log_odds_map[hit_index] =
+      clamp(log_odds_map[hit_index] + log_odds_hit_, log_odds_min_, log_odds_max_);
+  }
+}
+
+void SimpleSlam::rebuildCorrectedMap(const builtin_interfaces::msg::Time & stamp)
+{
+  corrected_map_log_odds_.assign(width_ * height_, 0.0);
+
+  for (const auto & keyframe : keyframes_) {
+    insertScanIntoLogOddsMap(
+      keyframe.scan,
+      keyframe.corrected_pose,
+      corrected_map_log_odds_);
+  }
+
+  updateCorrectedMapMessage(stamp);
+}
+
+void SimpleSlam::updateMapMessage(const builtin_interfaces::msg::Time & stamp)
+{
+  map_msg_.header.stamp = stamp;
+  occupied_cell_count_ = 0;
+
+  for (int i = 0; i < width_ * height_; ++i) {
+    double probability = 1.0 / (1.0 + std::exp(-map_log_odds_[i]));
+
+    if (map_log_odds_[i] == 0.0) {
+      map_msg_.data[i] = -1;
+    } else {
+      map_msg_.data[i] = static_cast<int8_t>(std::round(probability * 100.0));
+    }
+
+    if (map_msg_.data[i] > 50) {
+      occupied_cell_count_++;
+    }
+  }
+}
+
+void SimpleSlam::updateCorrectedMapMessage(const builtin_interfaces::msg::Time & stamp)
+{
+  corrected_map_msg_.header.stamp = stamp;
+
+  for (int i = 0; i < width_ * height_; ++i) {
+    double probability = 1.0 / (1.0 + std::exp(-corrected_map_log_odds_[i]));
+
+    if (corrected_map_log_odds_[i] == 0.0) {
+      corrected_map_msg_.data[i] = -1;
+    } else {
+      corrected_map_msg_.data[i] = static_cast<int8_t>(std::round(probability * 100.0));
+    }
+  }
+}
+
+void SimpleSlam::updateTrajectory(const builtin_interfaces::msg::Time & stamp)
+{
+  geometry_msgs::msg::PoseStamped pose;
+  pose.header.stamp = stamp;
+  pose.header.frame_id = "map";
+  pose.pose.position.x = slam_pose_.x;
+  pose.pose.position.y = slam_pose_.y;
+  pose.pose.orientation = yawToQuaternion(slam_pose_.theta);
+
+  trajectory_msg_.header.stamp = stamp;
+  trajectory_msg_.poses.push_back(pose);
+}
+
+void SimpleSlam::updateCorrectedTrajectory(const builtin_interfaces::msg::Time & stamp)
+{
+  corrected_trajectory_msg_.header.stamp = stamp;
+  corrected_trajectory_msg_.poses.clear();
+  corrected_trajectory_msg_.poses.reserve(keyframes_.size());
+
+  for (const auto & keyframe : keyframes_) {
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header.stamp = stamp;
+    pose.header.frame_id = "map";
+    pose.pose.position.x = keyframe.corrected_pose.x;
+    pose.pose.position.y = keyframe.corrected_pose.y;
+    pose.pose.orientation = yawToQuaternion(keyframe.corrected_pose.theta);
+    corrected_trajectory_msg_.poses.push_back(pose);
+  }
+}
+
+bool SimpleSlam::shouldAddKeyFrame() const
+{
+  if (!keyframe_initialized_) {
+    return true;
+  }
+
+  double distance = poseDistance(slam_pose_, last_keyframe_pose_);
+  double rotation = std::abs(normalizeAngle(slam_pose_.theta - last_keyframe_pose_.theta));
+
+  return distance >= keyframe_min_translation_ || rotation >= keyframe_min_rotation_;
+}
+
+void SimpleSlam::addKeyFrame(const sensor_msgs::msg::LaserScan & scan)
+{
+  KeyFrame keyframe;
+  keyframe.pose = slam_pose_;
+  keyframe.corrected_pose = slam_pose_;
+  keyframe.scan_signature = makeScanSignature(scan);
+  keyframe.scan = makeStoredScan(scan);
+  keyframe.scan_index = scans_integrated_;
+
+  keyframes_.push_back(keyframe);
+  last_keyframe_pose_ = slam_pose_;
+  keyframe_initialized_ = true;
+}
+
+LoopClosureResult SimpleSlam::detectLoopClosure()
+{
+  if (keyframes_.size() <= static_cast<std::size_t>(min_loop_closure_keyframe_age_)) {
+    return {};
+  }
+
+  if (scans_integrated_ - last_loop_closure_scan_ < min_loop_closure_scan_gap_) {
+    return {};
+  }
+
+  std::size_t current_index = keyframes_.size() - 1;
+  const KeyFrame & current_keyframe = keyframes_[current_index];
+  double best_difference = std::numeric_limits<double>::max();
+  std::size_t best_index = 0;
+  bool found_candidate = false;
+
+  for (std::size_t i = 0; i < current_index; ++i) {
+    const KeyFrame & keyframe = keyframes_[i];
+    int keyframe_age = current_keyframe.scan_index - keyframe.scan_index;
+    if (keyframe_age < min_loop_closure_keyframe_age_) {
+      continue;
+    }
+
+    double distance = poseDistance(current_keyframe.pose, keyframe.pose);
+    if (distance > loop_closure_search_radius_) {
+      continue;
+    }
+
+    double heading_difference =
+      std::abs(normalizeAngle(current_keyframe.pose.theta - keyframe.pose.theta));
+    if (heading_difference > loop_closure_max_heading_diff_) {
+      continue;
+    }
+
+    double signature_difference =
+      scanSignatureDifference(current_keyframe.scan_signature, keyframe.scan_signature);
+    if (signature_difference < best_difference) {
+      best_difference = signature_difference;
+      best_index = i;
+      found_candidate = true;
+    }
+  }
+
+  if (!found_candidate || best_difference > loop_closure_max_signature_diff_) {
+    return {};
+  }
+
+  loop_closure_count_++;
+  last_loop_closure_scan_ = scans_integrated_;
+  const KeyFrame & matched_keyframe = keyframes_[best_index];
+
+  LoopClosureResult result;
+  result.detected = true;
+  result.matched_pose = matched_keyframe.pose;
+  result.current_keyframe_index = current_index;
+  result.matched_keyframe_index = best_index;
+  result.matched_scan_index = matched_keyframe.scan_index;
+  result.signature_difference = best_difference;
+
+  if (shouldApplyLoopClosureCorrection(best_index, current_index)) {
+    applyLoopClosureCorrection(best_index, current_index);
+    result.correction_applied = true;
+  }
+
+  return result;
+}
+
+bool SimpleSlam::shouldApplyLoopClosureCorrection(
+  std::size_t old_index, std::size_t current_index) const
+{
+  if (current_index <= old_index) {
+    return false;
+  }
+
+  if (current_index - old_index < min_correction_keyframe_gap_) {
+    return false;
+  }
+
+  if (scans_integrated_ - last_correction_scan_ < min_correction_scan_gap_) {
+    return false;
+  }
+
+  if (last_corrected_old_keyframe_ != std::numeric_limits<std::size_t>::max()) {
+    std::size_t separation =
+      old_index > last_corrected_old_keyframe_ ?
+      old_index - last_corrected_old_keyframe_ :
+      last_corrected_old_keyframe_ - old_index;
+
+    if (separation < min_old_keyframe_separation_for_correction_) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void SimpleSlam::applyLoopClosureCorrection(
+  std::size_t old_index, std::size_t current_index)
+{
+  if (current_index <= old_index || current_index >= keyframes_.size()) {
+    return;
+  }
+
+  const Pose2D old_pose = keyframes_[old_index].corrected_pose;
+  const Pose2D current_pose = keyframes_[current_index].corrected_pose;
+
+  double error_x = loop_closure_correction_strength_ * (old_pose.x - current_pose.x);
+  double error_y = loop_closure_correction_strength_ * (old_pose.y - current_pose.y);
+  double error_theta =
+    loop_closure_correction_strength_ * normalizeAngle(old_pose.theta - current_pose.theta);
+  double span = static_cast<double>(current_index - old_index);
+
+  for (std::size_t i = old_index + 1; i <= current_index; ++i) {
+    double fraction = static_cast<double>(i - old_index) / span;
+    keyframes_[i].corrected_pose.x += fraction * error_x;
+    keyframes_[i].corrected_pose.y += fraction * error_y;
+    keyframes_[i].corrected_pose.theta =
+      normalizeAngle(keyframes_[i].corrected_pose.theta + fraction * error_theta);
+  }
+
+  loop_closure_correction_count_++;
+  last_correction_scan_ = scans_integrated_;
+  last_corrected_old_keyframe_ = old_index;
+}
+
+StoredScan SimpleSlam::makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const
+{
+  StoredScan stored_scan;
+  stored_scan.ranges = scan.ranges;
+  stored_scan.angle_min = scan.angle_min;
+  stored_scan.angle_increment = scan.angle_increment;
+  stored_scan.range_min = scan.range_min;
+  stored_scan.range_max = scan.range_max;
+  return stored_scan;
+}
+
+std::vector<float> SimpleSlam::makeScanSignature(
+  const sensor_msgs::msg::LaserScan & scan) const
+{
+  std::vector<float> signature;
+  signature.reserve(scan.ranges.size() / scan_signature_beam_step_ + 1);
+
+  for (std::size_t i = 0; i < scan.ranges.size(); i += scan_signature_beam_step_) {
+    float range = scan.ranges[i];
+    if (!std::isfinite(range) || range < scan.range_min) {
+      range = scan.range_max;
+    }
+
+    range = std::min(range, scan.range_max);
+    signature.push_back(range / scan.range_max);
+  }
+
+  return signature;
+}
+
+double SimpleSlam::scanSignatureDifference(
+  const std::vector<float> & first,
+  const std::vector<float> & second) const
+{
+  std::size_t count = std::min(first.size(), second.size());
+  if (count == 0) {
+    return std::numeric_limits<double>::max();
+  }
+
+  double difference_sum = 0.0;
+  for (std::size_t i = 0; i < count; ++i) {
+    difference_sum += std::abs(first[i] - second[i]);
+  }
+
+  return difference_sum / count;
+}
+
+double SimpleSlam::poseDistance(const Pose2D & first, const Pose2D & second) const
+{
+  double dx = first.x - second.x;
+  double dy = first.y - second.y;
+  return std::sqrt(dx * dx + dy * dy);
+}
+
+Pose2D SimpleSlam::odomMsgToPose(const nav_msgs::msg::Odometry & msg) const
+{
+  Pose2D pose;
+  pose.x = msg.pose.pose.position.x;
+  pose.y = msg.pose.pose.position.y;
+  pose.theta = tf2::getYaw(msg.pose.pose.orientation);
+  return pose;
+}
+
+bool SimpleSlam::odomMovedEnough(const Pose2D & old_odom, const Pose2D & new_odom) const
+{
+  double dx = new_odom.x - old_odom.x;
+  double dy = new_odom.y - old_odom.y;
+  double translation = std::sqrt(dx * dx + dy * dy);
+  double rotation = std::abs(normalizeAngle(new_odom.theta - old_odom.theta));
+
+  return translation >= min_update_translation_ || rotation >= min_update_rotation_;
+}
+
+geometry_msgs::msg::Quaternion SimpleSlam::yawToQuaternion(double yaw) const
+{
+  tf2::Quaternion quaternion;
+  quaternion.setRPY(0.0, 0.0, yaw);
+
+  geometry_msgs::msg::Quaternion msg;
+  msg.x = quaternion.x();
+  msg.y = quaternion.y();
+  msg.z = quaternion.z();
+  msg.w = quaternion.w();
+  return msg;
+}
+
+void SimpleSlam::worldToGrid(double wx, double wy, int & gx, int & gy) const
+{
+  gx = static_cast<int>(std::floor((wx - origin_x_) / resolution_));
+  gy = static_cast<int>(std::floor((wy - origin_y_) / resolution_));
+}
+
+bool SimpleSlam::isValidCell(int x, int y) const
+{
+  return x >= 0 && x < width_ && y >= 0 && y < height_;
+}
+
+std::vector<std::pair<int, int>> SimpleSlam::bresenhamLine(
+  int x0, int y0, int x1, int y1) const
+{
+  std::vector<std::pair<int, int>> cells;
+
+  int dx = std::abs(x1 - x0);
+  int dy = std::abs(y1 - y0);
+  int sx = x0 < x1 ? 1 : -1;
+  int sy = y0 < y1 ? 1 : -1;
+  int err = dx - dy;
+
+  int x = x0;
+  int y = y0;
+
+  while (true) {
+    cells.push_back({x, y});
+
+    if (x == x1 && y == y1) {
+      break;
+    }
+
+    int e2 = 2 * err;
+    if (e2 > -dy) {
+      err -= dy;
+      x += sx;
+    }
+    if (e2 < dx) {
+      err += dx;
+      y += sy;
+    }
+  }
+
+  return cells;
+}
+
+double SimpleSlam::normalizeAngle(double angle) const
+{
+  while (angle > M_PI) {
+    angle -= 2.0 * M_PI;
+  }
+  while (angle < -M_PI) {
+    angle += 2.0 * M_PI;
+  }
+  return angle;
+}
+
+double SimpleSlam::clamp(double value, double low, double high) const
+{
+  return std::min(std::max(value, low), high);
+}
+
+
+bool SimpleSlam::hasOdometry() const
+{
+  return odom_initialized_;
+}
+
+const Pose2D & SimpleSlam::slamPose() const
+{
+  return slam_pose_;
+}
+
+const Pose2D & SimpleSlam::currentOdomPose() const
+{
+  return current_odom_pose_;
+}
+
+const nav_msgs::msg::OccupancyGrid & SimpleSlam::map() const
+{
+  return map_msg_;
+}
+
+const nav_msgs::msg::OccupancyGrid & SimpleSlam::correctedMap() const
+{
+  return corrected_map_msg_;
+}
+
+const nav_msgs::msg::Path & SimpleSlam::trajectory() const
+{
+  return trajectory_msg_;
+}
+
+const nav_msgs::msg::Path & SimpleSlam::correctedTrajectory() const
+{
+  return corrected_trajectory_msg_;
+}
+
+int SimpleSlam::scansIntegrated() const
+{
+  return scans_integrated_;
+}
+
+int SimpleSlam::stationaryScansSkipped() const
+{
+  return stationary_scans_skipped_;
+}
+
+int SimpleSlam::scanMatchUsedCount() const
+{
+  return scan_match_used_count_;
+}
+
+int SimpleSlam::loopClosureCount() const
+{
+  return loop_closure_count_;
+}
+
+int SimpleSlam::loopClosureCorrectionCount() const
+{
+  return loop_closure_correction_count_;
+}
+
+int SimpleSlam::occupiedCellCount() const
+{
+  return occupied_cell_count_;
+}
+
+std::size_t SimpleSlam::keyframeCount() const
+{
+  return keyframes_.size();
+}
+
+}  // namespace slam

--- a/src/slam/src/simple_slam_node.cpp
+++ b/src/slam/src/simple_slam_node.cpp
@@ -24,6 +24,7 @@ private:
   void odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
   void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
 
+  slam::SimpleSlamConfig loadSlamConfig();
   void publishEstimatedPose(const builtin_interfaces::msg::Time & stamp);
   void publishScanMatchedPose(
     const slam::Pose2D & pose,
@@ -51,6 +52,8 @@ private:
 SimpleSlamNode::SimpleSlamNode()
 : Node("simple_slam_node")
 {
+  simple_slam_.configure(loadSlamConfig());
+
   odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
     "/odom", 10, std::bind(&SimpleSlamNode::odomCallback, this, std::placeholders::_1));
 
@@ -79,6 +82,87 @@ SimpleSlamNode::SimpleSlamNode()
     "Inputs: /odom, /scan. Outputs: /map, /corrected_map, /estimated_pose, "
     "/scan_matched_pose, /trajectory, /corrected_trajectory, /loop_closure_pose, "
     "TF map->odom.");
+}
+
+slam::SimpleSlamConfig SimpleSlamNode::loadSlamConfig()
+{
+  slam::SimpleSlamConfig config;
+
+  config.resolution = this->declare_parameter("resolution", config.resolution);
+  config.width = this->declare_parameter("width", config.width);
+  config.height = this->declare_parameter("height", config.height);
+  config.origin_x = this->declare_parameter("origin_x", config.origin_x);
+  config.origin_y = this->declare_parameter("origin_y", config.origin_y);
+
+  config.log_odds_hit = this->declare_parameter("log_odds_hit", config.log_odds_hit);
+  config.log_odds_free = this->declare_parameter("log_odds_free", config.log_odds_free);
+  config.log_odds_min = this->declare_parameter("log_odds_min", config.log_odds_min);
+  config.log_odds_max = this->declare_parameter("log_odds_max", config.log_odds_max);
+
+  config.min_occupied_cells_for_matching = this->declare_parameter(
+    "min_occupied_cells_for_matching", config.min_occupied_cells_for_matching);
+  config.likelihood_max_distance = this->declare_parameter(
+    "likelihood_max_distance", config.likelihood_max_distance);
+
+  config.scan_match_xy_range =
+    this->declare_parameter("scan_match_xy_range", config.scan_match_xy_range);
+  config.scan_match_xy_step =
+    this->declare_parameter("scan_match_xy_step", config.scan_match_xy_step);
+  config.scan_match_theta_range =
+    this->declare_parameter("scan_match_theta_range", config.scan_match_theta_range);
+  config.scan_match_theta_step =
+    this->declare_parameter("scan_match_theta_step", config.scan_match_theta_step);
+  config.scan_match_beam_step = static_cast<std::size_t>(
+    this->declare_parameter("scan_match_beam_step", static_cast<int>(config.scan_match_beam_step)));
+  config.min_scan_match_score =
+    this->declare_parameter("min_scan_match_score", config.min_scan_match_score);
+  config.min_scan_match_score_improvement = this->declare_parameter(
+    "min_scan_match_score_improvement", config.min_scan_match_score_improvement);
+  config.max_scan_match_translation_correction = this->declare_parameter(
+    "max_scan_match_translation_correction", config.max_scan_match_translation_correction);
+  config.max_scan_match_rotation_correction = this->declare_parameter(
+    "max_scan_match_rotation_correction", config.max_scan_match_rotation_correction);
+  config.min_scan_match_translation_interval = this->declare_parameter(
+    "min_scan_match_translation_interval", config.min_scan_match_translation_interval);
+  config.min_scan_match_rotation_interval = this->declare_parameter(
+    "min_scan_match_rotation_interval", config.min_scan_match_rotation_interval);
+  config.min_scan_match_scan_gap =
+    this->declare_parameter("min_scan_match_scan_gap", config.min_scan_match_scan_gap);
+  config.min_update_translation =
+    this->declare_parameter("min_update_translation", config.min_update_translation);
+  config.min_update_rotation =
+    this->declare_parameter("min_update_rotation", config.min_update_rotation);
+
+  config.keyframe_min_translation =
+    this->declare_parameter("keyframe_min_translation", config.keyframe_min_translation);
+  config.keyframe_min_rotation =
+    this->declare_parameter("keyframe_min_rotation", config.keyframe_min_rotation);
+  config.scan_signature_beam_step = static_cast<std::size_t>(
+    this->declare_parameter(
+      "scan_signature_beam_step", static_cast<int>(config.scan_signature_beam_step)));
+  config.min_loop_closure_keyframe_age = this->declare_parameter(
+    "min_loop_closure_keyframe_age", config.min_loop_closure_keyframe_age);
+  config.loop_closure_search_radius =
+    this->declare_parameter("loop_closure_search_radius", config.loop_closure_search_radius);
+  config.loop_closure_max_heading_diff = this->declare_parameter(
+    "loop_closure_max_heading_diff", config.loop_closure_max_heading_diff);
+  config.loop_closure_max_signature_diff = this->declare_parameter(
+    "loop_closure_max_signature_diff", config.loop_closure_max_signature_diff);
+  config.min_loop_closure_scan_gap =
+    this->declare_parameter("min_loop_closure_scan_gap", config.min_loop_closure_scan_gap);
+  config.min_correction_scan_gap =
+    this->declare_parameter("min_correction_scan_gap", config.min_correction_scan_gap);
+  config.min_correction_keyframe_gap = static_cast<std::size_t>(
+    this->declare_parameter(
+      "min_correction_keyframe_gap", static_cast<int>(config.min_correction_keyframe_gap)));
+  config.min_old_keyframe_separation_for_correction = static_cast<std::size_t>(
+    this->declare_parameter(
+      "min_old_keyframe_separation_for_correction",
+      static_cast<int>(config.min_old_keyframe_separation_for_correction)));
+  config.loop_closure_correction_strength = this->declare_parameter(
+    "loop_closure_correction_strength", config.loop_closure_correction_strength);
+
+  return config;
 }
 
 void SimpleSlamNode::odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)

--- a/src/slam/src/simple_slam_node.cpp
+++ b/src/slam/src/simple_slam_node.cpp
@@ -1,3 +1,5 @@
+#include "slam/simple_slam.hpp"
+
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
@@ -8,1045 +10,254 @@
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2/LinearMath/Transform.h"
-#include "tf2/utils.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2_ros/transform_broadcaster.h"
 
-#include <algorithm>
-#include <cmath>
-#include <limits>
-#include <queue>
-#include <utility>
-#include <vector>
-
-struct Pose2D
-{
-    double x = 0.0;
-    double y = 0.0;
-    double theta = 0.0;
-};
-
-struct ScanMatchResult
-{
-    Pose2D pose;
-    double score = 0.0;
-    double predicted_score = 0.0;
-    bool used_scan_matching = false;
-};
-
-struct StoredScan
-{
-    std::vector<float> ranges;
-    float angle_min = 0.0F;
-    float angle_increment = 0.0F;
-    float range_min = 0.0F;
-    float range_max = 0.0F;
-};
-
-struct KeyFrame
-{
-    Pose2D pose;
-    Pose2D corrected_pose;
-    std::vector<float> scan_signature;
-    StoredScan scan;
-    int scan_index = 0;
-};
+#include <memory>
 
 class SimpleSlamNode : public rclcpp::Node
 {
 public:
-    SimpleSlamNode();
+  SimpleSlamNode();
 
 private:
-    void odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
-    void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
+  void odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
+  void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
 
-    void initializeMap();
-    void rebuildLikelihoodField();
-    ScanMatchResult matchScan(const sensor_msgs::msg::LaserScan & scan, const Pose2D & predicted);
-    double scoreScanAtPose(const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose) const;
-    double likelihoodAtWorld(double x, double y) const;
+  void publishEstimatedPose(const builtin_interfaces::msg::Time & stamp);
+  void publishScanMatchedPose(
+    const slam::Pose2D & pose,
+    const builtin_interfaces::msg::Time & stamp);
+  void publishLoopClosurePose(
+    const slam::Pose2D & pose,
+    const builtin_interfaces::msg::Time & stamp);
+  void publishMapToOdomTf(const builtin_interfaces::msg::Time & stamp);
+  geometry_msgs::msg::Quaternion yawToQuaternion(double yaw) const;
 
-    void updateMapWithScan(const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose);
-    void insertScanIntoLogOddsMap(
-        const StoredScan & scan,
-        const Pose2D & pose,
-        std::vector<double> & log_odds_map);
-    void rebuildCorrectedMap(const rclcpp::Time & stamp);
-    void publishMap();
-    void publishCorrectedMap(const rclcpp::Time & stamp);
-    void publishEstimatedPose(const rclcpp::Time & stamp);
-    void publishScanMatchedPose(const Pose2D & pose, const rclcpp::Time & stamp);
-    void publishMapToOdomTf(const rclcpp::Time & stamp);
-    void updateTrajectory(const rclcpp::Time & stamp);
-    void publishCorrectedTrajectory(const rclcpp::Time & stamp);
-    void publishLoopClosurePose(const Pose2D & pose, const rclcpp::Time & stamp);
+  slam::SimpleSlam simple_slam_;
 
-    bool shouldAddKeyFrame() const;
-    void addKeyFrame(const sensor_msgs::msg::LaserScan & scan);
-    bool detectLoopClosure(const rclcpp::Time & stamp);
-    bool shouldApplyLoopClosureCorrection(std::size_t old_index, std::size_t current_index) const;
-    void applyLoopClosureCorrection(std::size_t old_index, std::size_t current_index);
-    StoredScan makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const;
-    std::vector<float> makeScanSignature(const sensor_msgs::msg::LaserScan & scan) const;
-    double scanSignatureDifference(
-        const std::vector<float> & first,
-        const std::vector<float> & second) const;
-    double poseDistance(const Pose2D & first, const Pose2D & second) const;
-
-    Pose2D odomMsgToPose(const nav_msgs::msg::Odometry & msg) const;
-    Pose2D applyOdomDeltaToSlamPose(const Pose2D & old_odom, const Pose2D & new_odom) const;
-    bool odomMovedEnough(const Pose2D & old_odom, const Pose2D & new_odom) const;
-    geometry_msgs::msg::Quaternion yawToQuaternion(double yaw) const;
-
-    void worldToGrid(double wx, double wy, int & gx, int & gy) const;
-    bool isValidCell(int x, int y) const;
-    std::vector<std::pair<int, int>> bresenhamLine(int x0, int y0, int x1, int y1) const;
-    double normalizeAngle(double angle) const;
-    double clamp(double value, double low, double high) const;
-
-    rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
-    rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
-    rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_pub_;
-    rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr corrected_map_pub_;
-    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr estimated_pose_pub_;
-    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr scan_matched_pose_pub_;
-    rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr trajectory_pub_;
-    rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr corrected_trajectory_pub_;
-    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr loop_closure_pose_pub_;
-    std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
-
-    nav_msgs::msg::OccupancyGrid map_msg_;
-    nav_msgs::msg::OccupancyGrid corrected_map_msg_;
-    nav_msgs::msg::OccupancyGrid likelihood_field_msg_;
-    nav_msgs::msg::Path trajectory_msg_;
-    nav_msgs::msg::Path corrected_trajectory_msg_;
-    std::vector<double> map_log_odds_;
-    std::vector<double> corrected_map_log_odds_;
-    std::vector<KeyFrame> keyframes_;
-
-    Pose2D slam_pose_;
-    Pose2D last_odom_pose_;
-    Pose2D current_odom_pose_;
-    Pose2D last_keyframe_pose_;
-    Pose2D last_scan_match_pose_;
-    bool odom_initialized_ = false;
-    bool scan_received_ = false;
-    bool keyframe_initialized_ = false;
-    bool scan_match_pose_initialized_ = false;
-
-    double resolution_ = 0.05;
-    int width_ = 500;
-    int height_ = 500;
-    double origin_x_ = -12.5;
-    double origin_y_ = -12.5;
-
-    double log_odds_hit_ = 2.89;
-    double log_odds_free_ = -2.25;
-    double log_odds_min_ = -10.0;
-    double log_odds_max_ = 10.0;
-
-    int occupied_cell_count_ = 0;
-    int min_occupied_cells_for_matching_ = 250;
-    bool likelihood_field_dirty_ = true;
-    double likelihood_max_distance_ = 1.0;
-
-    double search_xy_range_ = 0.10;
-    double search_xy_step_ = 0.05;
-    double search_theta_range_ = 0.08;
-    double search_theta_step_ = 0.04;
-    std::size_t scan_match_beam_step_ = 10;
-    double min_scan_match_score_ = 0.20;
-    double min_scan_match_score_improvement_ = 0.003;
-    double max_scan_match_translation_correction_ = 0.08;
-    double max_scan_match_rotation_correction_ = 0.08;
-    double min_scan_match_translation_interval_ = 0.02;
-    double min_scan_match_rotation_interval_ = 0.02;
-    int min_scan_match_scan_gap_ = 2;
-    double min_update_translation_ = 0.01;
-    double min_update_rotation_ = 0.01;
-
-    double keyframe_min_translation_ = 0.25;
-    double keyframe_min_rotation_ = 0.25;
-    std::size_t scan_signature_beam_step_ = 20;
-    int min_loop_closure_keyframe_age_ = 20;
-    double loop_closure_search_radius_ = 0.45;
-    double loop_closure_max_heading_diff_ = 0.70;
-    double loop_closure_max_signature_diff_ = 0.18;
-    int min_loop_closure_scan_gap_ = 20;
-    int min_correction_scan_gap_ = 80;
-    std::size_t min_correction_keyframe_gap_ = 12;
-    std::size_t min_old_keyframe_separation_for_correction_ = 8;
-    double loop_closure_correction_strength_ = 0.35;
-
-    int scans_integrated_ = 0;
-    int stationary_scans_skipped_ = 0;
-    int scan_match_used_count_ = 0;
-    int loop_closure_count_ = 0;
-    int loop_closure_correction_count_ = 0;
-    int last_scan_match_scan_ = -100000;
-    int last_loop_closure_scan_ = -100000;
-    int last_correction_scan_ = -100000;
-    std::size_t last_corrected_old_keyframe_ = std::numeric_limits<std::size_t>::max();
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_pub_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr corrected_map_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr estimated_pose_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr scan_matched_pose_pub_;
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr trajectory_pub_;
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr corrected_trajectory_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr loop_closure_pose_pub_;
+  std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 };
 
 SimpleSlamNode::SimpleSlamNode()
 : Node("simple_slam_node")
 {
-    initializeMap();
+  odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+    "/odom", 10, std::bind(&SimpleSlamNode::odomCallback, this, std::placeholders::_1));
 
-    odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
-        "/odom", 10, std::bind(&SimpleSlamNode::odomCallback, this, std::placeholders::_1));
+  scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>(
+    "/scan", 10, std::bind(&SimpleSlamNode::scanCallback, this, std::placeholders::_1));
 
-    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>(
-        "/scan", 10, std::bind(&SimpleSlamNode::scanCallback, this, std::placeholders::_1));
+  auto map_qos = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();
+  map_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("/map", map_qos);
+  corrected_map_pub_ =
+    this->create_publisher<nav_msgs::msg::OccupancyGrid>("/corrected_map", map_qos);
+  estimated_pose_pub_ =
+    this->create_publisher<geometry_msgs::msg::PoseStamped>("/estimated_pose", 10);
+  scan_matched_pose_pub_ =
+    this->create_publisher<geometry_msgs::msg::PoseStamped>("/scan_matched_pose", 10);
+  trajectory_pub_ = this->create_publisher<nav_msgs::msg::Path>("/trajectory", 10);
+  corrected_trajectory_pub_ =
+    this->create_publisher<nav_msgs::msg::Path>("/corrected_trajectory", 10);
+  loop_closure_pose_pub_ =
+    this->create_publisher<geometry_msgs::msg::PoseStamped>("/loop_closure_pose", 10);
 
-    auto map_qos = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();
-    map_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("/map", map_qos);
-    corrected_map_pub_ =
-        this->create_publisher<nav_msgs::msg::OccupancyGrid>("/corrected_map", map_qos);
-    estimated_pose_pub_ =
-        this->create_publisher<geometry_msgs::msg::PoseStamped>("/estimated_pose", 10);
-    scan_matched_pose_pub_ =
-        this->create_publisher<geometry_msgs::msg::PoseStamped>("/scan_matched_pose", 10);
-    trajectory_pub_ = this->create_publisher<nav_msgs::msg::Path>("/trajectory", 10);
-    corrected_trajectory_pub_ =
-        this->create_publisher<nav_msgs::msg::Path>("/corrected_trajectory", 10);
-    loop_closure_pose_pub_ =
-        this->create_publisher<geometry_msgs::msg::PoseStamped>("/loop_closure_pose", 10);
+  tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
 
-    tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
-
-    RCLCPP_INFO(this->get_logger(), "Simple SLAM node started.");
-    RCLCPP_INFO(
-        this->get_logger(),
-        "Inputs: /odom, /scan. Outputs: /map, /corrected_map, /estimated_pose, /scan_matched_pose, /trajectory, /corrected_trajectory, /loop_closure_pose, TF map->odom.");
-}
-
-void SimpleSlamNode::initializeMap()
-{
-    origin_x_ = -width_ * resolution_ / 2.0;
-    origin_y_ = -height_ * resolution_ / 2.0;
-
-    map_log_odds_.assign(width_ * height_, 0.0);
-    corrected_map_log_odds_.assign(width_ * height_, 0.0);
-
-    map_msg_.header.frame_id = "map";
-    map_msg_.info.resolution = resolution_;
-    map_msg_.info.width = width_;
-    map_msg_.info.height = height_;
-    map_msg_.info.origin.position.x = origin_x_;
-    map_msg_.info.origin.position.y = origin_y_;
-    map_msg_.info.origin.orientation.w = 1.0;
-    map_msg_.data.assign(width_ * height_, -1);
-    corrected_map_msg_ = map_msg_;
-
-    likelihood_field_msg_ = map_msg_;
-    likelihood_field_msg_.data.assign(width_ * height_, 0);
-
-    trajectory_msg_.header.frame_id = "map";
-    corrected_trajectory_msg_.header.frame_id = "map";
+  RCLCPP_INFO(this->get_logger(), "Simple SLAM node started.");
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Inputs: /odom, /scan. Outputs: /map, /corrected_map, /estimated_pose, "
+    "/scan_matched_pose, /trajectory, /corrected_trajectory, /loop_closure_pose, "
+    "TF map->odom.");
 }
 
 void SimpleSlamNode::odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
 {
-    current_odom_pose_ = odomMsgToPose(*msg);
+  bool first_odom_received = simple_slam_.handleOdometry(*msg);
 
-    if (!odom_initialized_) {
-        last_odom_pose_ = current_odom_pose_;
-        odom_initialized_ = true;
-        publishEstimatedPose(msg->header.stamp);
-        publishMapToOdomTf(msg->header.stamp);
-        RCLCPP_INFO(this->get_logger(), "First odom received. SLAM pose starts at map origin.");
-    }
+  if (first_odom_received) {
+    publishEstimatedPose(msg->header.stamp);
+    publishMapToOdomTf(msg->header.stamp);
+    RCLCPP_INFO(this->get_logger(), "First odom received. SLAM pose starts at map origin.");
+  }
 }
 
 void SimpleSlamNode::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
 {
-    if (!odom_initialized_) {
-        RCLCPP_WARN_THROTTLE(
-            this->get_logger(), *this->get_clock(), 2000, "Waiting for /odom before using scans.");
-        return;
-    }
+  if (!simple_slam_.hasOdometry()) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 2000, "Waiting for /odom before using scans.");
+    return;
+  }
 
-    bool moved_enough = odomMovedEnough(last_odom_pose_, current_odom_pose_);
-    Pose2D predicted_pose = applyOdomDeltaToSlamPose(last_odom_pose_, current_odom_pose_);
-    last_odom_pose_ = current_odom_pose_;
+  slam::SlamUpdateResult update = simple_slam_.handleScan(*msg, msg->header.stamp);
 
-    if (scan_received_ && !moved_enough) {
-        stationary_scans_skipped_++;
-        publishEstimatedPose(msg->header.stamp);
-        publishMapToOdomTf(msg->header.stamp);
-        return;
-    }
-
-    ScanMatchResult result = matchScan(*msg, predicted_pose);
-    slam_pose_ = result.pose;
-
-    updateMapWithScan(*msg, slam_pose_);
-    publishMap();
+  if (update.stationary_scan_skipped) {
     publishEstimatedPose(msg->header.stamp);
-    if (result.used_scan_matching) {
-        publishScanMatchedPose(result.pose, msg->header.stamp);
-    }
     publishMapToOdomTf(msg->header.stamp);
+    return;
+  }
 
-    scan_received_ = true;
-    scans_integrated_++;
-    likelihood_field_dirty_ = true;
-    updateTrajectory(msg->header.stamp);
-    if (shouldAddKeyFrame()) {
-        addKeyFrame(*msg);
-        detectLoopClosure(msg->header.stamp);
-    }
-    publishCorrectedTrajectory(msg->header.stamp);
+  if (!update.scan_integrated) {
+    return;
+  }
 
-    RCLCPP_INFO_THROTTLE(
-        this->get_logger(),
-        *this->get_clock(),
-        5000,
-        "SLAM integrated=%d stationary_skipped=%d scan_match_used=%d keyframes=%zu loops=%d corrections=%d pose=(%.2f, %.2f, %.2f) match=%s score=%.3f predicted_score=%.3f occupied=%d",
-        scans_integrated_,
-        stationary_scans_skipped_,
-        scan_match_used_count_,
-        keyframes_.size(),
-        loop_closure_count_,
-        loop_closure_correction_count_,
-        slam_pose_.x,
-        slam_pose_.y,
-        slam_pose_.theta,
-        result.used_scan_matching ? "yes" : "no",
-        result.score,
-        result.predicted_score,
-        occupied_cell_count_);
-}
+  if (update.map_updated) {
+    map_pub_->publish(simple_slam_.map());
+  }
 
-Pose2D SimpleSlamNode::applyOdomDeltaToSlamPose(
-    const Pose2D & old_odom, const Pose2D & new_odom) const
-{
-    double odom_dx = new_odom.x - old_odom.x;
-    double odom_dy = new_odom.y - old_odom.y;
-    double old_odom_theta = old_odom.theta;
+  publishEstimatedPose(msg->header.stamp);
 
-    double local_dx =
-        std::cos(old_odom_theta) * odom_dx + std::sin(old_odom_theta) * odom_dy;
-    double local_dy =
-        -std::sin(old_odom_theta) * odom_dx + std::cos(old_odom_theta) * odom_dy;
-    double local_dtheta = normalizeAngle(new_odom.theta - old_odom.theta);
+  if (update.scan_match.used_scan_matching) {
+    publishScanMatchedPose(update.scan_match.pose, msg->header.stamp);
+  }
 
-    Pose2D predicted = slam_pose_;
-    predicted.x += std::cos(slam_pose_.theta) * local_dx -
-        std::sin(slam_pose_.theta) * local_dy;
-    predicted.y += std::sin(slam_pose_.theta) * local_dx +
-        std::cos(slam_pose_.theta) * local_dy;
-    predicted.theta = normalizeAngle(slam_pose_.theta + local_dtheta);
-    return predicted;
-}
+  publishMapToOdomTf(msg->header.stamp);
 
-ScanMatchResult SimpleSlamNode::matchScan(
-    const sensor_msgs::msg::LaserScan & scan, const Pose2D & predicted)
-{
-    ScanMatchResult result;
-    result.pose = predicted;
+  if (update.trajectory_updated) {
+    trajectory_pub_->publish(simple_slam_.trajectory());
+  }
 
-    if (!scan_received_) {
-        return result;
-    }
+  if (update.corrected_trajectory_updated) {
+    corrected_trajectory_pub_->publish(simple_slam_.correctedTrajectory());
+  }
 
-    if (scans_integrated_ - last_scan_match_scan_ < min_scan_match_scan_gap_) {
-        return result;
-    }
-
-    if (occupied_cell_count_ < min_occupied_cells_for_matching_) {
-        return result;
-    }
-
-    if (scan_match_pose_initialized_) {
-        double distance_since_last_match = poseDistance(predicted, last_scan_match_pose_);
-        double rotation_since_last_match =
-            std::abs(normalizeAngle(predicted.theta - last_scan_match_pose_.theta));
-        if (distance_since_last_match < min_scan_match_translation_interval_ &&
-            rotation_since_last_match < min_scan_match_rotation_interval_)
-        {
-            return result;
-        }
-    }
-
-    if (likelihood_field_dirty_) {
-        rebuildLikelihoodField();
-        likelihood_field_dirty_ = false;
-    }
-
-    result.predicted_score = scoreScanAtPose(scan, predicted);
-
-    double best_score = -std::numeric_limits<double>::infinity();
-    Pose2D best_pose = predicted;
-
-    for (double dx = -search_xy_range_; dx <= search_xy_range_ + 1e-9; dx += search_xy_step_) {
-        for (double dy = -search_xy_range_; dy <= search_xy_range_ + 1e-9; dy += search_xy_step_) {
-            for (double dtheta = -search_theta_range_;
-                dtheta <= search_theta_range_ + 1e-9;
-                dtheta += search_theta_step_)
-            {
-                Pose2D candidate;
-                candidate.x = predicted.x + dx;
-                candidate.y = predicted.y + dy;
-                candidate.theta = normalizeAngle(predicted.theta + dtheta);
-
-                double score = scoreScanAtPose(scan, candidate);
-                if (score > best_score) {
-                    best_score = score;
-                    best_pose = candidate;
-                }
-            }
-        }
-    }
-
-    result.score = std::max(best_score, 0.0);
-
-    double correction_translation = poseDistance(best_pose, predicted);
-    double correction_rotation =
-        std::abs(normalizeAngle(best_pose.theta - predicted.theta));
-    double score_improvement = result.score - result.predicted_score;
-
-    if (best_score >= min_scan_match_score_ &&
-        score_improvement >= min_scan_match_score_improvement_ &&
-        correction_translation <= max_scan_match_translation_correction_ &&
-        correction_rotation <= max_scan_match_rotation_correction_)
-    {
-        result.pose = best_pose;
-        result.used_scan_matching = true;
-        scan_match_used_count_++;
-        last_scan_match_scan_ = scans_integrated_;
-        last_scan_match_pose_ = result.pose;
-        scan_match_pose_initialized_ = true;
-    }
-
-    return result;
-}
-
-void SimpleSlamNode::rebuildLikelihoodField()
-{
-    likelihood_field_msg_ = map_msg_;
-    likelihood_field_msg_.data.assign(width_ * height_, 0);
-
-    int max_distance_cells = static_cast<int>(std::ceil(likelihood_max_distance_ / resolution_));
-    std::vector<int> distance_to_wall(width_ * height_, max_distance_cells + 1);
-    std::queue<int> cells_to_visit;
-
-    for (int row = 0; row < height_; ++row) {
-        for (int col = 0; col < width_; ++col) {
-            int index = row * width_ + col;
-            if (map_msg_.data[index] > 50) {
-                distance_to_wall[index] = 0;
-                cells_to_visit.push(index);
-            }
-        }
-    }
-
-    const int neighbor_offsets[4][2] = {
-        {1, 0},
-        {-1, 0},
-        {0, 1},
-        {0, -1}
-    };
-
-    while (!cells_to_visit.empty()) {
-        int index = cells_to_visit.front();
-        cells_to_visit.pop();
-
-        int row = index / width_;
-        int col = index % width_;
-        int next_distance = distance_to_wall[index] + 1;
-
-        if (next_distance > max_distance_cells) {
-            continue;
-        }
-
-        for (const auto & offset : neighbor_offsets) {
-            int next_col = col + offset[0];
-            int next_row = row + offset[1];
-
-            if (!isValidCell(next_col, next_row)) {
-                continue;
-            }
-
-            int next_index = next_row * width_ + next_col;
-            if (next_distance >= distance_to_wall[next_index]) {
-                continue;
-            }
-
-            distance_to_wall[next_index] = next_distance;
-            cells_to_visit.push(next_index);
-        }
-    }
-
-    for (int i = 0; i < width_ * height_; ++i) {
-        if (distance_to_wall[i] > max_distance_cells) {
-            continue;
-        }
-
-        double distance_m = distance_to_wall[i] * resolution_;
-        double likelihood = 1.0 - std::min(distance_m / likelihood_max_distance_, 1.0);
-        likelihood_field_msg_.data[i] = static_cast<int8_t>(std::round(likelihood * 100.0));
-    }
-}
-
-double SimpleSlamNode::scoreScanAtPose(
-    const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose) const
-{
-    double score = 0.0;
-    int used_beams = 0;
-
-    for (std::size_t i = 0; i < scan.ranges.size(); i += scan_match_beam_step_) {
-        float range = scan.ranges[i];
-
-        if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
-            continue;
-        }
-
-        double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
-        double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
-        double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
-
-        score += likelihoodAtWorld(hit_x, hit_y);
-        used_beams++;
-    }
-
-    if (used_beams == 0) {
-        return 0.0;
-    }
-
-    return score / used_beams;
-}
-
-double SimpleSlamNode::likelihoodAtWorld(double x, double y) const
-{
-    int col = 0;
-    int row = 0;
-    worldToGrid(x, y, col, row);
-
-    if (!isValidCell(col, row)) {
-        return 0.0;
-    }
-
-    int index = row * width_ + col;
-    return likelihood_field_msg_.data[index] / 100.0;
-}
-
-void SimpleSlamNode::updateMapWithScan(
-    const sensor_msgs::msg::LaserScan & scan, const Pose2D & pose)
-{
-    insertScanIntoLogOddsMap(makeStoredScan(scan), pose, map_log_odds_);
-}
-
-void SimpleSlamNode::insertScanIntoLogOddsMap(
-    const StoredScan & scan,
-    const Pose2D & pose,
-    std::vector<double> & log_odds_map)
-{
-    int robot_grid_x = 0;
-    int robot_grid_y = 0;
-    worldToGrid(pose.x, pose.y, robot_grid_x, robot_grid_y);
-
-    if (!isValidCell(robot_grid_x, robot_grid_y)) {
-        RCLCPP_WARN(this->get_logger(), "SLAM pose outside map bounds; scan skipped.");
-        return;
-    }
-
-    for (std::size_t i = 0; i < scan.ranges.size(); ++i) {
-        float range = scan.ranges[i];
-
-        if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
-            continue;
-        }
-
-        double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
-        double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
-        double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
-
-        int hit_grid_x = 0;
-        int hit_grid_y = 0;
-        worldToGrid(hit_x, hit_y, hit_grid_x, hit_grid_y);
-
-        if (!isValidCell(hit_grid_x, hit_grid_y)) {
-            continue;
-        }
-
-        auto cells = bresenhamLine(robot_grid_x, robot_grid_y, hit_grid_x, hit_grid_y);
-        if (cells.empty()) {
-            continue;
-        }
-
-        for (std::size_t cell_index = 0; cell_index + 1 < cells.size(); ++cell_index) {
-            int x = cells[cell_index].first;
-            int y = cells[cell_index].second;
-            int index = y * width_ + x;
-            log_odds_map[index] =
-                clamp(log_odds_map[index] + log_odds_free_, log_odds_min_, log_odds_max_);
-        }
-
-        int hit_index = cells.back().second * width_ + cells.back().first;
-        log_odds_map[hit_index] =
-            clamp(log_odds_map[hit_index] + log_odds_hit_, log_odds_min_, log_odds_max_);
-    }
-}
-
-void SimpleSlamNode::rebuildCorrectedMap(const rclcpp::Time & stamp)
-{
-    corrected_map_log_odds_.assign(width_ * height_, 0.0);
-
-    for (const auto & keyframe : keyframes_) {
-        insertScanIntoLogOddsMap(
-            keyframe.scan,
-            keyframe.corrected_pose,
-            corrected_map_log_odds_);
-    }
-
-    publishCorrectedMap(stamp);
-}
-
-void SimpleSlamNode::publishMap()
-{
-    map_msg_.header.stamp = this->now();
-    occupied_cell_count_ = 0;
-
-    for (int i = 0; i < width_ * height_; ++i) {
-        double probability = 1.0 / (1.0 + std::exp(-map_log_odds_[i]));
-
-        if (map_log_odds_[i] == 0.0) {
-            map_msg_.data[i] = -1;
-        } else {
-            map_msg_.data[i] = static_cast<int8_t>(std::round(probability * 100.0));
-        }
-
-        if (map_msg_.data[i] > 50) {
-            occupied_cell_count_++;
-        }
-    }
-
-    map_pub_->publish(map_msg_);
-}
-
-void SimpleSlamNode::publishCorrectedMap(const rclcpp::Time & stamp)
-{
-    corrected_map_msg_.header.stamp = stamp;
-
-    for (int i = 0; i < width_ * height_; ++i) {
-        double probability = 1.0 / (1.0 + std::exp(-corrected_map_log_odds_[i]));
-
-        if (corrected_map_log_odds_[i] == 0.0) {
-            corrected_map_msg_.data[i] = -1;
-        } else {
-            corrected_map_msg_.data[i] = static_cast<int8_t>(std::round(probability * 100.0));
-        }
-    }
-
-    corrected_map_pub_->publish(corrected_map_msg_);
-}
-
-void SimpleSlamNode::publishEstimatedPose(const rclcpp::Time & stamp)
-{
-    geometry_msgs::msg::PoseStamped msg;
-    msg.header.stamp = stamp;
-    msg.header.frame_id = "map";
-    msg.pose.position.x = slam_pose_.x;
-    msg.pose.position.y = slam_pose_.y;
-    msg.pose.orientation = yawToQuaternion(slam_pose_.theta);
-    estimated_pose_pub_->publish(msg);
-}
-
-void SimpleSlamNode::publishScanMatchedPose(const Pose2D & pose, const rclcpp::Time & stamp)
-{
-    geometry_msgs::msg::PoseStamped msg;
-    msg.header.stamp = stamp;
-    msg.header.frame_id = "map";
-    msg.pose.position.x = pose.x;
-    msg.pose.position.y = pose.y;
-    msg.pose.orientation = yawToQuaternion(pose.theta);
-    scan_matched_pose_pub_->publish(msg);
-}
-
-void SimpleSlamNode::publishMapToOdomTf(const rclcpp::Time & stamp)
-{
-    tf2::Quaternion map_to_base_rotation;
-    map_to_base_rotation.setRPY(0.0, 0.0, slam_pose_.theta);
-
-    tf2::Transform map_to_base;
-    map_to_base.setOrigin(tf2::Vector3(slam_pose_.x, slam_pose_.y, 0.0));
-    map_to_base.setRotation(map_to_base_rotation);
-
-    tf2::Quaternion odom_to_base_rotation;
-    odom_to_base_rotation.setRPY(0.0, 0.0, current_odom_pose_.theta);
-
-    tf2::Transform odom_to_base;
-    odom_to_base.setOrigin(tf2::Vector3(current_odom_pose_.x, current_odom_pose_.y, 0.0));
-    odom_to_base.setRotation(odom_to_base_rotation);
-
-    tf2::Transform map_to_odom = map_to_base * odom_to_base.inverse();
-
-    geometry_msgs::msg::TransformStamped msg;
-    msg.header.stamp = stamp;
-    msg.header.frame_id = "map";
-    msg.child_frame_id = "odom";
-    msg.transform = tf2::toMsg(map_to_odom);
-    tf_broadcaster_->sendTransform(msg);
-}
-
-void SimpleSlamNode::updateTrajectory(const rclcpp::Time & stamp)
-{
-    geometry_msgs::msg::PoseStamped pose;
-    pose.header.stamp = stamp;
-    pose.header.frame_id = "map";
-    pose.pose.position.x = slam_pose_.x;
-    pose.pose.position.y = slam_pose_.y;
-    pose.pose.orientation = yawToQuaternion(slam_pose_.theta);
-
-    trajectory_msg_.header.stamp = stamp;
-    trajectory_msg_.poses.push_back(pose);
-    trajectory_pub_->publish(trajectory_msg_);
-}
-
-void SimpleSlamNode::publishCorrectedTrajectory(const rclcpp::Time & stamp)
-{
-    corrected_trajectory_msg_.header.stamp = stamp;
-    corrected_trajectory_msg_.poses.clear();
-    corrected_trajectory_msg_.poses.reserve(keyframes_.size());
-
-    for (const auto & keyframe : keyframes_) {
-        geometry_msgs::msg::PoseStamped pose;
-        pose.header.stamp = stamp;
-        pose.header.frame_id = "map";
-        pose.pose.position.x = keyframe.corrected_pose.x;
-        pose.pose.position.y = keyframe.corrected_pose.y;
-        pose.pose.orientation = yawToQuaternion(keyframe.corrected_pose.theta);
-        corrected_trajectory_msg_.poses.push_back(pose);
-    }
-
-    corrected_trajectory_pub_->publish(corrected_trajectory_msg_);
-}
-
-void SimpleSlamNode::publishLoopClosurePose(const Pose2D & pose, const rclcpp::Time & stamp)
-{
-    geometry_msgs::msg::PoseStamped msg;
-    msg.header.stamp = stamp;
-    msg.header.frame_id = "map";
-    msg.pose.position.x = pose.x;
-    msg.pose.position.y = pose.y;
-    msg.pose.orientation = yawToQuaternion(pose.theta);
-    loop_closure_pose_pub_->publish(msg);
-}
-
-bool SimpleSlamNode::shouldAddKeyFrame() const
-{
-    if (!keyframe_initialized_) {
-        return true;
-    }
-
-    double distance = poseDistance(slam_pose_, last_keyframe_pose_);
-    double rotation = std::abs(normalizeAngle(slam_pose_.theta - last_keyframe_pose_.theta));
-
-    return distance >= keyframe_min_translation_ || rotation >= keyframe_min_rotation_;
-}
-
-void SimpleSlamNode::addKeyFrame(const sensor_msgs::msg::LaserScan & scan)
-{
-    KeyFrame keyframe;
-    keyframe.pose = slam_pose_;
-    keyframe.corrected_pose = slam_pose_;
-    keyframe.scan_signature = makeScanSignature(scan);
-    keyframe.scan = makeStoredScan(scan);
-    keyframe.scan_index = scans_integrated_;
-
-    keyframes_.push_back(keyframe);
-    last_keyframe_pose_ = slam_pose_;
-    keyframe_initialized_ = true;
-}
-
-bool SimpleSlamNode::detectLoopClosure(const rclcpp::Time & stamp)
-{
-    if (keyframes_.size() <= static_cast<std::size_t>(min_loop_closure_keyframe_age_)) {
-        return false;
-    }
-
-    if (scans_integrated_ - last_loop_closure_scan_ < min_loop_closure_scan_gap_) {
-        return false;
-    }
-
-    std::size_t current_index = keyframes_.size() - 1;
-    const KeyFrame & current_keyframe = keyframes_[current_index];
-    double best_difference = std::numeric_limits<double>::max();
-    std::size_t best_index = 0;
-    bool found_candidate = false;
-
-    for (std::size_t i = 0; i < current_index; ++i) {
-        const KeyFrame & keyframe = keyframes_[i];
-        int keyframe_age = current_keyframe.scan_index - keyframe.scan_index;
-        if (keyframe_age < min_loop_closure_keyframe_age_) {
-            continue;
-        }
-
-        double distance = poseDistance(current_keyframe.pose, keyframe.pose);
-        if (distance > loop_closure_search_radius_) {
-            continue;
-        }
-
-        double heading_difference =
-            std::abs(normalizeAngle(current_keyframe.pose.theta - keyframe.pose.theta));
-        if (heading_difference > loop_closure_max_heading_diff_) {
-            continue;
-        }
-
-        double signature_difference =
-            scanSignatureDifference(current_keyframe.scan_signature, keyframe.scan_signature);
-        if (signature_difference < best_difference) {
-            best_difference = signature_difference;
-            best_index = i;
-            found_candidate = true;
-        }
-    }
-
-    if (!found_candidate || best_difference > loop_closure_max_signature_diff_) {
-        return false;
-    }
-
-    loop_closure_count_++;
-    last_loop_closure_scan_ = scans_integrated_;
-    const KeyFrame & matched_keyframe = keyframes_[best_index];
-    publishLoopClosurePose(matched_keyframe.pose, stamp);
-
-    bool correction_applied = false;
-    if (shouldApplyLoopClosureCorrection(best_index, current_index)) {
-        applyLoopClosureCorrection(best_index, current_index);
-        publishCorrectedTrajectory(stamp);
-        rebuildCorrectedMap(stamp);
-        correction_applied = true;
-    }
-
+  if (update.loop_closure.detected) {
+    publishLoopClosurePose(update.loop_closure.matched_pose, msg->header.stamp);
     RCLCPP_INFO(
-        this->get_logger(),
-        "Loop closure detected: current_scan=%d current_keyframe=%zu matched_keyframe=%zu old_scan=%d signature_diff=%.3f correction=%s",
-        scans_integrated_,
-        current_index,
-        best_index,
-        matched_keyframe.scan_index,
-        best_difference,
-        correction_applied ? "applied" : "skipped");
+      this->get_logger(),
+      "Loop closure detected: current_scan=%d current_keyframe=%zu matched_keyframe=%zu "
+      "old_scan=%d signature_diff=%.3f correction=%s",
+      simple_slam_.scansIntegrated(),
+      update.loop_closure.current_keyframe_index,
+      update.loop_closure.matched_keyframe_index,
+      update.loop_closure.matched_scan_index,
+      update.loop_closure.signature_difference,
+      update.loop_closure.correction_applied ? "applied" : "skipped");
+  }
 
-    return true;
+  if (update.corrected_map_updated) {
+    corrected_map_pub_->publish(simple_slam_.correctedMap());
+  }
+
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(),
+    5000,
+    "SLAM integrated=%d stationary_skipped=%d scan_match_used=%d keyframes=%zu "
+    "loops=%d corrections=%d pose=(%.2f, %.2f, %.2f) match=%s score=%.3f "
+    "predicted_score=%.3f occupied=%d",
+    simple_slam_.scansIntegrated(),
+    simple_slam_.stationaryScansSkipped(),
+    simple_slam_.scanMatchUsedCount(),
+    simple_slam_.keyframeCount(),
+    simple_slam_.loopClosureCount(),
+    simple_slam_.loopClosureCorrectionCount(),
+    simple_slam_.slamPose().x,
+    simple_slam_.slamPose().y,
+    simple_slam_.slamPose().theta,
+    update.scan_match.used_scan_matching ? "yes" : "no",
+    update.scan_match.score,
+    update.scan_match.predicted_score,
+    simple_slam_.occupiedCellCount());
 }
 
-bool SimpleSlamNode::shouldApplyLoopClosureCorrection(
-    std::size_t old_index, std::size_t current_index) const
+void SimpleSlamNode::publishEstimatedPose(const builtin_interfaces::msg::Time & stamp)
 {
-    if (current_index <= old_index) {
-        return false;
-    }
+  const slam::Pose2D & slam_pose = simple_slam_.slamPose();
 
-    if (current_index - old_index < min_correction_keyframe_gap_) {
-        return false;
-    }
-
-    if (scans_integrated_ - last_correction_scan_ < min_correction_scan_gap_) {
-        return false;
-    }
-
-    if (last_corrected_old_keyframe_ != std::numeric_limits<std::size_t>::max()) {
-        std::size_t separation =
-            old_index > last_corrected_old_keyframe_ ?
-            old_index - last_corrected_old_keyframe_ :
-            last_corrected_old_keyframe_ - old_index;
-
-        if (separation < min_old_keyframe_separation_for_correction_) {
-            return false;
-        }
-    }
-
-    return true;
+  geometry_msgs::msg::PoseStamped msg;
+  msg.header.stamp = stamp;
+  msg.header.frame_id = "map";
+  msg.pose.position.x = slam_pose.x;
+  msg.pose.position.y = slam_pose.y;
+  msg.pose.orientation = yawToQuaternion(slam_pose.theta);
+  estimated_pose_pub_->publish(msg);
 }
 
-void SimpleSlamNode::applyLoopClosureCorrection(
-    std::size_t old_index, std::size_t current_index)
+void SimpleSlamNode::publishScanMatchedPose(
+  const slam::Pose2D & pose,
+  const builtin_interfaces::msg::Time & stamp)
 {
-    if (current_index <= old_index || current_index >= keyframes_.size()) {
-        return;
-    }
-
-    const Pose2D old_pose = keyframes_[old_index].corrected_pose;
-    const Pose2D current_pose = keyframes_[current_index].corrected_pose;
-
-    double error_x = loop_closure_correction_strength_ * (old_pose.x - current_pose.x);
-    double error_y = loop_closure_correction_strength_ * (old_pose.y - current_pose.y);
-    double error_theta =
-        loop_closure_correction_strength_ * normalizeAngle(old_pose.theta - current_pose.theta);
-    double span = static_cast<double>(current_index - old_index);
-
-    for (std::size_t i = old_index + 1; i <= current_index; ++i) {
-        double fraction = static_cast<double>(i - old_index) / span;
-        keyframes_[i].corrected_pose.x += fraction * error_x;
-        keyframes_[i].corrected_pose.y += fraction * error_y;
-        keyframes_[i].corrected_pose.theta =
-            normalizeAngle(keyframes_[i].corrected_pose.theta + fraction * error_theta);
-    }
-
-    loop_closure_correction_count_++;
-    last_correction_scan_ = scans_integrated_;
-    last_corrected_old_keyframe_ = old_index;
+  geometry_msgs::msg::PoseStamped msg;
+  msg.header.stamp = stamp;
+  msg.header.frame_id = "map";
+  msg.pose.position.x = pose.x;
+  msg.pose.position.y = pose.y;
+  msg.pose.orientation = yawToQuaternion(pose.theta);
+  scan_matched_pose_pub_->publish(msg);
 }
 
-StoredScan SimpleSlamNode::makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const
+void SimpleSlamNode::publishLoopClosurePose(
+  const slam::Pose2D & pose,
+  const builtin_interfaces::msg::Time & stamp)
 {
-    StoredScan stored_scan;
-    stored_scan.ranges = scan.ranges;
-    stored_scan.angle_min = scan.angle_min;
-    stored_scan.angle_increment = scan.angle_increment;
-    stored_scan.range_min = scan.range_min;
-    stored_scan.range_max = scan.range_max;
-    return stored_scan;
+  geometry_msgs::msg::PoseStamped msg;
+  msg.header.stamp = stamp;
+  msg.header.frame_id = "map";
+  msg.pose.position.x = pose.x;
+  msg.pose.position.y = pose.y;
+  msg.pose.orientation = yawToQuaternion(pose.theta);
+  loop_closure_pose_pub_->publish(msg);
 }
 
-std::vector<float> SimpleSlamNode::makeScanSignature(
-    const sensor_msgs::msg::LaserScan & scan) const
+void SimpleSlamNode::publishMapToOdomTf(const builtin_interfaces::msg::Time & stamp)
 {
-    std::vector<float> signature;
-    signature.reserve(scan.ranges.size() / scan_signature_beam_step_ + 1);
+  const slam::Pose2D & slam_pose = simple_slam_.slamPose();
+  const slam::Pose2D & odom_pose = simple_slam_.currentOdomPose();
 
-    for (std::size_t i = 0; i < scan.ranges.size(); i += scan_signature_beam_step_) {
-        float range = scan.ranges[i];
-        if (!std::isfinite(range) || range < scan.range_min) {
-            range = scan.range_max;
-        }
+  tf2::Quaternion map_to_base_rotation;
+  map_to_base_rotation.setRPY(0.0, 0.0, slam_pose.theta);
 
-        range = std::min(range, scan.range_max);
-        signature.push_back(range / scan.range_max);
-    }
+  tf2::Transform map_to_base;
+  map_to_base.setOrigin(tf2::Vector3(slam_pose.x, slam_pose.y, 0.0));
+  map_to_base.setRotation(map_to_base_rotation);
 
-    return signature;
-}
+  tf2::Quaternion odom_to_base_rotation;
+  odom_to_base_rotation.setRPY(0.0, 0.0, odom_pose.theta);
 
-double SimpleSlamNode::scanSignatureDifference(
-    const std::vector<float> & first,
-    const std::vector<float> & second) const
-{
-    std::size_t count = std::min(first.size(), second.size());
-    if (count == 0) {
-        return std::numeric_limits<double>::max();
-    }
+  tf2::Transform odom_to_base;
+  odom_to_base.setOrigin(tf2::Vector3(odom_pose.x, odom_pose.y, 0.0));
+  odom_to_base.setRotation(odom_to_base_rotation);
 
-    double difference_sum = 0.0;
-    for (std::size_t i = 0; i < count; ++i) {
-        difference_sum += std::abs(first[i] - second[i]);
-    }
+  tf2::Transform map_to_odom = map_to_base * odom_to_base.inverse();
 
-    return difference_sum / count;
-}
-
-double SimpleSlamNode::poseDistance(const Pose2D & first, const Pose2D & second) const
-{
-    double dx = first.x - second.x;
-    double dy = first.y - second.y;
-    return std::sqrt(dx * dx + dy * dy);
-}
-
-Pose2D SimpleSlamNode::odomMsgToPose(const nav_msgs::msg::Odometry & msg) const
-{
-    Pose2D pose;
-    pose.x = msg.pose.pose.position.x;
-    pose.y = msg.pose.pose.position.y;
-    pose.theta = tf2::getYaw(msg.pose.pose.orientation);
-    return pose;
-}
-
-bool SimpleSlamNode::odomMovedEnough(const Pose2D & old_odom, const Pose2D & new_odom) const
-{
-    double dx = new_odom.x - old_odom.x;
-    double dy = new_odom.y - old_odom.y;
-    double translation = std::sqrt(dx * dx + dy * dy);
-    double rotation = std::abs(normalizeAngle(new_odom.theta - old_odom.theta));
-
-    return translation >= min_update_translation_ || rotation >= min_update_rotation_;
+  geometry_msgs::msg::TransformStamped msg;
+  msg.header.stamp = stamp;
+  msg.header.frame_id = "map";
+  msg.child_frame_id = "odom";
+  msg.transform = tf2::toMsg(map_to_odom);
+  tf_broadcaster_->sendTransform(msg);
 }
 
 geometry_msgs::msg::Quaternion SimpleSlamNode::yawToQuaternion(double yaw) const
 {
-    tf2::Quaternion quaternion;
-    quaternion.setRPY(0.0, 0.0, yaw);
+  tf2::Quaternion quaternion;
+  quaternion.setRPY(0.0, 0.0, yaw);
 
-    geometry_msgs::msg::Quaternion msg;
-    msg.x = quaternion.x();
-    msg.y = quaternion.y();
-    msg.z = quaternion.z();
-    msg.w = quaternion.w();
-    return msg;
-}
-
-void SimpleSlamNode::worldToGrid(double wx, double wy, int & gx, int & gy) const
-{
-    gx = static_cast<int>(std::floor((wx - origin_x_) / resolution_));
-    gy = static_cast<int>(std::floor((wy - origin_y_) / resolution_));
-}
-
-bool SimpleSlamNode::isValidCell(int x, int y) const
-{
-    return x >= 0 && x < width_ && y >= 0 && y < height_;
-}
-
-std::vector<std::pair<int, int>> SimpleSlamNode::bresenhamLine(
-    int x0, int y0, int x1, int y1) const
-{
-    std::vector<std::pair<int, int>> cells;
-
-    int dx = std::abs(x1 - x0);
-    int dy = std::abs(y1 - y0);
-    int sx = x0 < x1 ? 1 : -1;
-    int sy = y0 < y1 ? 1 : -1;
-    int err = dx - dy;
-
-    int x = x0;
-    int y = y0;
-
-    while (true) {
-        cells.push_back({x, y});
-
-        if (x == x1 && y == y1) {
-            break;
-        }
-
-        int e2 = 2 * err;
-        if (e2 > -dy) {
-            err -= dy;
-            x += sx;
-        }
-        if (e2 < dx) {
-            err += dx;
-            y += sy;
-        }
-    }
-
-    return cells;
-}
-
-double SimpleSlamNode::normalizeAngle(double angle) const
-{
-    while (angle > M_PI) {
-        angle -= 2.0 * M_PI;
-    }
-    while (angle < -M_PI) {
-        angle += 2.0 * M_PI;
-    }
-    return angle;
-}
-
-double SimpleSlamNode::clamp(double value, double low, double high) const
-{
-    return std::min(std::max(value, low), high);
+  geometry_msgs::msg::Quaternion msg;
+  msg.x = quaternion.x();
+  msg.y = quaternion.y();
+  msg.z = quaternion.z();
+  msg.w = quaternion.w();
+  return msg;
 }
 
 int main(int argc, char ** argv)
 {
-    rclcpp::init(argc, argv);
-    auto node = std::make_shared<SimpleSlamNode>();
-    rclcpp::spin(node);
-    rclcpp::shutdown();
-    return 0;
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<SimpleSlamNode>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
 }

--- a/src/slam/src/slam_localization.cpp
+++ b/src/slam/src/slam_localization.cpp
@@ -1,0 +1,284 @@
+#include "slam/slam_localization.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <queue>
+
+namespace slam
+{
+
+void SlamLocalization::configure(const SimpleSlamConfig & config)
+{
+  min_occupied_cells_for_matching_ = config.min_occupied_cells_for_matching;
+  likelihood_max_distance_ = config.likelihood_max_distance;
+
+  scan_match_xy_range_ = config.scan_match_xy_range;
+  scan_match_xy_step_ = config.scan_match_xy_step;
+  scan_match_theta_range_ = config.scan_match_theta_range;
+  scan_match_theta_step_ = config.scan_match_theta_step;
+  scan_match_beam_step_ = config.scan_match_beam_step;
+  min_scan_match_score_ = config.min_scan_match_score;
+  min_scan_match_score_improvement_ = config.min_scan_match_score_improvement;
+  max_scan_match_translation_correction_ = config.max_scan_match_translation_correction;
+  max_scan_match_rotation_correction_ = config.max_scan_match_rotation_correction;
+  min_scan_match_translation_interval_ = config.min_scan_match_translation_interval;
+  min_scan_match_rotation_interval_ = config.min_scan_match_rotation_interval;
+  min_scan_match_scan_gap_ = config.min_scan_match_scan_gap;
+
+  likelihood_field_dirty_ = true;
+  scan_match_pose_initialized_ = false;
+  scan_match_used_count_ = 0;
+  last_scan_match_scan_index_ = -100000;
+}
+
+void SlamLocalization::markMapDirty()
+{
+  likelihood_field_dirty_ = true;
+}
+
+ScanMatchResult SlamLocalization::matchScan(
+  const sensor_msgs::msg::LaserScan & scan,
+  const Pose2D & predicted_pose,
+  const nav_msgs::msg::OccupancyGrid & map,
+  bool scan_received,
+  int scans_integrated,
+  int occupied_cell_count)
+{
+  ScanMatchResult result;
+  result.pose = predicted_pose;
+
+  if (!scan_received) {
+    return result;
+  }
+
+  if (scans_integrated - last_scan_match_scan_index_ < min_scan_match_scan_gap_) {
+    return result;
+  }
+
+  if (occupied_cell_count < min_occupied_cells_for_matching_) {
+    return result;
+  }
+
+  if (scan_match_pose_initialized_) {
+    double distance_since_last_match = poseDistance(predicted_pose, last_scan_match_pose_);
+    double rotation_since_last_match =
+      std::abs(normalizeAngle(predicted_pose.theta - last_scan_match_pose_.theta));
+    if (distance_since_last_match < min_scan_match_translation_interval_ &&
+      rotation_since_last_match < min_scan_match_rotation_interval_)
+    {
+      return result;
+    }
+  }
+
+  if (likelihood_field_dirty_) {
+    rebuildLikelihoodField(map);
+    likelihood_field_dirty_ = false;
+  }
+
+  result.predicted_score = scoreScanAtPose(scan, predicted_pose);
+
+  double best_score = -std::numeric_limits<double>::infinity();
+  Pose2D best_pose = predicted_pose;
+
+  for (double dx = -scan_match_xy_range_; dx <= scan_match_xy_range_ + 1e-9;
+    dx += scan_match_xy_step_)
+  {
+    for (double dy = -scan_match_xy_range_; dy <= scan_match_xy_range_ + 1e-9;
+      dy += scan_match_xy_step_)
+    {
+      for (double dtheta = -scan_match_theta_range_;
+        dtheta <= scan_match_theta_range_ + 1e-9;
+        dtheta += scan_match_theta_step_)
+      {
+        Pose2D candidate;
+        candidate.x = predicted_pose.x + dx;
+        candidate.y = predicted_pose.y + dy;
+        candidate.theta = normalizeAngle(predicted_pose.theta + dtheta);
+
+        double score = scoreScanAtPose(scan, candidate);
+        if (score > best_score) {
+          best_score = score;
+          best_pose = candidate;
+        }
+      }
+    }
+  }
+
+  result.score = std::max(best_score, 0.0);
+
+  double correction_translation = poseDistance(best_pose, predicted_pose);
+  double correction_rotation =
+    std::abs(normalizeAngle(best_pose.theta - predicted_pose.theta));
+  double score_improvement = result.score - result.predicted_score;
+
+  if (best_score >= min_scan_match_score_ &&
+    score_improvement >= min_scan_match_score_improvement_ &&
+    correction_translation <= max_scan_match_translation_correction_ &&
+    correction_rotation <= max_scan_match_rotation_correction_)
+  {
+    result.pose = best_pose;
+    result.used_scan_matching = true;
+    scan_match_used_count_++;
+    last_scan_match_scan_index_ = scans_integrated;
+    last_scan_match_pose_ = result.pose;
+    scan_match_pose_initialized_ = true;
+  }
+
+  return result;
+}
+
+int SlamLocalization::scanMatchUsedCount() const
+{
+  return scan_match_used_count_;
+}
+
+void SlamLocalization::rebuildLikelihoodField(const nav_msgs::msg::OccupancyGrid & map)
+{
+  likelihood_field_msg_ = map;
+  likelihood_field_msg_.data.assign(map.info.width * map.info.height, 0);
+
+  int width = static_cast<int>(map.info.width);
+  int height = static_cast<int>(map.info.height);
+  double resolution = map.info.resolution;
+  int max_distance_cells = static_cast<int>(std::ceil(likelihood_max_distance_ / resolution));
+  std::vector<int> distance_to_wall(width * height, max_distance_cells + 1);
+  std::queue<int> cells_to_visit;
+
+  for (int row = 0; row < height; ++row) {
+    for (int col = 0; col < width; ++col) {
+      int index = row * width + col;
+      if (map.data[index] > 50) {
+        distance_to_wall[index] = 0;
+        cells_to_visit.push(index);
+      }
+    }
+  }
+
+  const int neighbor_offsets[4][2] = {
+    {1, 0},
+    {-1, 0},
+    {0, 1},
+    {0, -1}
+  };
+
+  while (!cells_to_visit.empty()) {
+    int index = cells_to_visit.front();
+    cells_to_visit.pop();
+
+    int row = index / width;
+    int col = index % width;
+    int next_distance = distance_to_wall[index] + 1;
+
+    if (next_distance > max_distance_cells) {
+      continue;
+    }
+
+    for (const auto & offset : neighbor_offsets) {
+      int next_col = col + offset[0];
+      int next_row = row + offset[1];
+
+      if (next_col < 0 || next_col >= width || next_row < 0 || next_row >= height) {
+        continue;
+      }
+
+      int next_index = next_row * width + next_col;
+      if (next_distance >= distance_to_wall[next_index]) {
+        continue;
+      }
+
+      distance_to_wall[next_index] = next_distance;
+      cells_to_visit.push(next_index);
+    }
+  }
+
+  for (int i = 0; i < width * height; ++i) {
+    if (distance_to_wall[i] > max_distance_cells) {
+      continue;
+    }
+
+    double distance_m = distance_to_wall[i] * resolution;
+    double likelihood = 1.0 - std::min(distance_m / likelihood_max_distance_, 1.0);
+    likelihood_field_msg_.data[i] = static_cast<int8_t>(std::round(likelihood * 100.0));
+  }
+}
+
+double SlamLocalization::scoreScanAtPose(
+  const sensor_msgs::msg::LaserScan & scan,
+  const Pose2D & pose) const
+{
+  double score = 0.0;
+  int used_beams = 0;
+
+  for (std::size_t i = 0; i < scan.ranges.size(); i += scan_match_beam_step_) {
+    float range = scan.ranges[i];
+
+    if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
+      continue;
+    }
+
+    double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
+    double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
+    double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
+
+    score += likelihoodAtWorld(hit_x, hit_y);
+    used_beams++;
+  }
+
+  if (used_beams == 0) {
+    return 0.0;
+  }
+
+  return score / used_beams;
+}
+
+double SlamLocalization::likelihoodAtWorld(double x, double y) const
+{
+  int col = 0;
+  int row = 0;
+  if (!worldToGrid(x, y, col, row)) {
+    return 0.0;
+  }
+
+  int width = static_cast<int>(likelihood_field_msg_.info.width);
+  int index = row * width + col;
+  return likelihood_field_msg_.data[index] / 100.0;
+}
+
+bool SlamLocalization::worldToGrid(double wx, double wy, int & gx, int & gy) const
+{
+  double resolution = likelihood_field_msg_.info.resolution;
+  double origin_x = likelihood_field_msg_.info.origin.position.x;
+  double origin_y = likelihood_field_msg_.info.origin.position.y;
+
+  gx = static_cast<int>(std::floor((wx - origin_x) / resolution));
+  gy = static_cast<int>(std::floor((wy - origin_y) / resolution));
+  return isValidCell(gx, gy);
+}
+
+bool SlamLocalization::isValidCell(int x, int y) const
+{
+  int width = static_cast<int>(likelihood_field_msg_.info.width);
+  int height = static_cast<int>(likelihood_field_msg_.info.height);
+  return x >= 0 && x < width && y >= 0 && y < height;
+}
+
+double SlamLocalization::normalizeAngle(double angle) const
+{
+  while (angle > M_PI) {
+    angle -= 2.0 * M_PI;
+  }
+  while (angle < -M_PI) {
+    angle += 2.0 * M_PI;
+  }
+  return angle;
+}
+
+double SlamLocalization::poseDistance(const Pose2D & first, const Pose2D & second) const
+{
+  double dx = first.x - second.x;
+  double dy = first.y - second.y;
+  return std::sqrt(dx * dx + dy * dy);
+}
+
+}  // namespace slam

--- a/src/slam/src/slam_localization.cpp
+++ b/src/slam/src/slam_localization.cpp
@@ -32,7 +32,7 @@ void SlamLocalization::configure(const SimpleSlamConfig & config)
   last_scan_match_scan_index_ = -100000;
 }
 
-void SlamLocalization::markMapDirty()
+void SlamLocalization::markMapDirtyForScanMatching()
 {
   likelihood_field_dirty_ = true;
 }

--- a/src/slam/src/slam_mapper.cpp
+++ b/src/slam/src/slam_mapper.cpp
@@ -1,0 +1,229 @@
+#include "slam/slam_mapper.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace slam
+{
+
+void SlamMapper::configure(const SimpleSlamConfig & config)
+{
+  resolution_ = config.resolution;
+  width_ = config.width;
+  height_ = config.height;
+  origin_x_ = config.origin_x;
+  origin_y_ = config.origin_y;
+
+  log_odds_hit_ = config.log_odds_hit;
+  log_odds_free_ = config.log_odds_free;
+  log_odds_min_ = config.log_odds_min;
+  log_odds_max_ = config.log_odds_max;
+
+  initializeMap();
+}
+
+void SlamMapper::updateWithScan(
+  const sensor_msgs::msg::LaserScan & scan,
+  const Pose2D & pose,
+  const builtin_interfaces::msg::Time & stamp)
+{
+  insertScanIntoLogOddsMap(makeStoredScan(scan), pose, map_log_odds_);
+  updateMapMessage(stamp);
+}
+
+void SlamMapper::rebuildCorrectedMap(
+  const std::vector<KeyFrame> & keyframes,
+  const builtin_interfaces::msg::Time & stamp)
+{
+  corrected_map_log_odds_.assign(width_ * height_, 0.0);
+
+  for (const auto & keyframe : keyframes) {
+    insertScanIntoLogOddsMap(
+      keyframe.scan,
+      keyframe.corrected_pose,
+      corrected_map_log_odds_);
+  }
+
+  updateCorrectedMapMessage(stamp);
+}
+
+const nav_msgs::msg::OccupancyGrid & SlamMapper::map() const
+{
+  return map_msg_;
+}
+
+const nav_msgs::msg::OccupancyGrid & SlamMapper::correctedMap() const
+{
+  return corrected_map_msg_;
+}
+
+int SlamMapper::occupiedCellCount() const
+{
+  return occupied_cell_count_;
+}
+
+void SlamMapper::initializeMap()
+{
+  map_log_odds_.assign(width_ * height_, 0.0);
+  corrected_map_log_odds_.assign(width_ * height_, 0.0);
+
+  map_msg_.header.frame_id = "map";
+  map_msg_.info.resolution = resolution_;
+  map_msg_.info.width = width_;
+  map_msg_.info.height = height_;
+  map_msg_.info.origin.position.x = origin_x_;
+  map_msg_.info.origin.position.y = origin_y_;
+  map_msg_.info.origin.orientation.w = 1.0;
+  map_msg_.data.assign(width_ * height_, -1);
+  corrected_map_msg_ = map_msg_;
+}
+
+void SlamMapper::insertScanIntoLogOddsMap(
+  const StoredScan & scan,
+  const Pose2D & pose,
+  std::vector<double> & log_odds_map)
+{
+  int robot_grid_x = 0;
+  int robot_grid_y = 0;
+  worldToGrid(pose.x, pose.y, robot_grid_x, robot_grid_y);
+
+  if (!isValidCell(robot_grid_x, robot_grid_y)) {
+    return;
+  }
+
+  for (std::size_t i = 0; i < scan.ranges.size(); ++i) {
+    float range = scan.ranges[i];
+
+    if (!std::isfinite(range) || range < scan.range_min || range > scan.range_max) {
+      continue;
+    }
+
+    double beam_angle = scan.angle_min + static_cast<double>(i) * scan.angle_increment;
+    double hit_x = pose.x + range * std::cos(pose.theta + beam_angle);
+    double hit_y = pose.y + range * std::sin(pose.theta + beam_angle);
+
+    int hit_grid_x = 0;
+    int hit_grid_y = 0;
+    worldToGrid(hit_x, hit_y, hit_grid_x, hit_grid_y);
+
+    if (!isValidCell(hit_grid_x, hit_grid_y)) {
+      continue;
+    }
+
+    auto cells = bresenhamLine(robot_grid_x, robot_grid_y, hit_grid_x, hit_grid_y);
+    if (cells.empty()) {
+      continue;
+    }
+
+    for (std::size_t cell_index = 0; cell_index + 1 < cells.size(); ++cell_index) {
+      int x = cells[cell_index].first;
+      int y = cells[cell_index].second;
+      int index = y * width_ + x;
+      log_odds_map[index] =
+        clamp(log_odds_map[index] + log_odds_free_, log_odds_min_, log_odds_max_);
+    }
+
+    int hit_index = cells.back().second * width_ + cells.back().first;
+    log_odds_map[hit_index] =
+      clamp(log_odds_map[hit_index] + log_odds_hit_, log_odds_min_, log_odds_max_);
+  }
+}
+
+void SlamMapper::updateMapMessage(const builtin_interfaces::msg::Time & stamp)
+{
+  map_msg_.header.stamp = stamp;
+  occupied_cell_count_ = 0;
+
+  for (int i = 0; i < width_ * height_; ++i) {
+    double probability = 1.0 / (1.0 + std::exp(-map_log_odds_[i]));
+
+    if (map_log_odds_[i] == 0.0) {
+      map_msg_.data[i] = -1;
+    } else {
+      map_msg_.data[i] = static_cast<int8_t>(std::round(probability * 100.0));
+    }
+
+    if (map_msg_.data[i] > 50) {
+      occupied_cell_count_++;
+    }
+  }
+}
+
+void SlamMapper::updateCorrectedMapMessage(const builtin_interfaces::msg::Time & stamp)
+{
+  corrected_map_msg_.header.stamp = stamp;
+
+  for (int i = 0; i < width_ * height_; ++i) {
+    double probability = 1.0 / (1.0 + std::exp(-corrected_map_log_odds_[i]));
+
+    if (corrected_map_log_odds_[i] == 0.0) {
+      corrected_map_msg_.data[i] = -1;
+    } else {
+      corrected_map_msg_.data[i] = static_cast<int8_t>(std::round(probability * 100.0));
+    }
+  }
+}
+
+StoredScan SlamMapper::makeStoredScan(const sensor_msgs::msg::LaserScan & scan) const
+{
+  StoredScan stored_scan;
+  stored_scan.ranges = scan.ranges;
+  stored_scan.angle_min = scan.angle_min;
+  stored_scan.angle_increment = scan.angle_increment;
+  stored_scan.range_min = scan.range_min;
+  stored_scan.range_max = scan.range_max;
+  return stored_scan;
+}
+
+void SlamMapper::worldToGrid(double wx, double wy, int & gx, int & gy) const
+{
+  gx = static_cast<int>(std::floor((wx - origin_x_) / resolution_));
+  gy = static_cast<int>(std::floor((wy - origin_y_) / resolution_));
+}
+
+bool SlamMapper::isValidCell(int x, int y) const
+{
+  return x >= 0 && x < width_ && y >= 0 && y < height_;
+}
+
+std::vector<std::pair<int, int>> SlamMapper::bresenhamLine(
+  int x0, int y0, int x1, int y1) const
+{
+  std::vector<std::pair<int, int>> cells;
+
+  int dx = std::abs(x1 - x0);
+  int dy = std::abs(y1 - y0);
+  int sx = x0 < x1 ? 1 : -1;
+  int sy = y0 < y1 ? 1 : -1;
+  int err = dx - dy;
+
+  int x = x0;
+  int y = y0;
+
+  while (true) {
+    cells.push_back({x, y});
+
+    if (x == x1 && y == y1) {
+      break;
+    }
+
+    int e2 = 2 * err;
+    if (e2 > -dy) {
+      err -= dy;
+      x += sx;
+    }
+    if (e2 < dx) {
+      err += dx;
+      y += sy;
+    }
+  }
+
+  return cells;
+}
+
+double SlamMapper::clamp(double value, double low, double high) const
+{
+  return std::min(std::max(value, low), high);
+}
+
+}  // namespace slam


### PR DESCRIPTION
## Summary

- Split the SLAM implementation into a ROS wrapper plus focused algorithm components: mapper, localization, and loop closure.
- Added `SimpleSlamConfig` and `slam.yaml` so SLAM tuning values can be changed through launch-time parameters.
- Updated the SLAM README with package status, code organization, parameters, run instructions, and current limitations.
- Added small teaching comments around the main `SimpleSlam::handleScan()` flow.

## Validation

- `colcon build --packages-select slam`
- `colcon test --packages-select slam`
- Manual functionality test confirmed behavior still works as before.